### PR TITLE
Pass opts to load-fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,8 @@ SCI supports loading code via a hook that is invoked by SCI's implementation of
 `require`. The job of this function is to find and return the source code for
 the requested namespace. This passed-in function will be called with a single
 argument that is a hashmap with a key `:namespace`. The value for this key will
-be the _symbol_ of the requested namespace.
+be the _symbol_ of the requested namespace. Also a `:opts` key contains options
+from the require call, such as `:as`.
 
 This function should return a map with keys `:file` (containing the filename to
 be used in error messages) and `:source` (containing the source code text). SCI

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ SCI supports loading code via a hook that is invoked by SCI's implementation of
 the requested namespace. This passed-in function will be called with a single
 argument that is a hashmap with a key `:namespace`. The value for this key will
 be the _symbol_ of the requested namespace. Also a `:opts` key contains options
-from the require call, such as `:as`.
+from the require call, currently only `:as`.
 
 This function should return a map with keys `:file` (containing the filename to
 be used in error messages) and `:source` (containing the source code text). SCI

--- a/src/sci/impl/load.cljc
+++ b/src/sci/impl/load.cljc
@@ -90,9 +90,9 @@
            lib)
           (reset! env* (handle-require-libspec-env ctx env cnn the-loaded-ns lib opts))))
       (if-let [load-fn (:load-fn env)]
-        (if-let [{:keys [:file :source]} (load-fn {:namespace lib
-                                                   :opts (select-keys opts [:as])
-                                                   :reload (or reload reload-all)})]
+        (if-let [{:keys [:file :source :omit-as-alias?]} (load-fn {:namespace lib
+                                                                   :opts (select-keys opts [:as])
+                                                                   :reload (or reload reload-all)})]
           (do
             (let [ctx (-> ctx
                           (assoc :bindings {})
@@ -113,7 +113,9 @@
                                 the-loaded-ns (get namespaces lib)]
                             (handle-require-libspec-env ctx env cnn
                                                         the-loaded-ns
-                                                        lib opts)))))
+                                                        lib (if omit-as-alias?
+                                                              (dissoc opts :as) ;; Allows load-fn to setup aliases
+                                                              opts))))))
           (or (when reload*
                 (when-let [the-loaded-ns (get namespaces lib)]
                   (reset! env* (handle-require-libspec-env ctx env cnn the-loaded-ns lib opts))))

--- a/src/sci/impl/load.cljc
+++ b/src/sci/impl/load.cljc
@@ -91,7 +91,7 @@
           (reset! env* (handle-require-libspec-env ctx env cnn the-loaded-ns lib opts))))
       (if-let [load-fn (:load-fn env)]
         (if-let [{:keys [:file :source]} (load-fn {:namespace lib
-                                                   :opts opts
+                                                   :opts (select-keys opts [:as])
                                                    :reload (or reload reload-all)})]
           (do
             (let [ctx (-> ctx

--- a/src/sci/impl/load.cljc
+++ b/src/sci/impl/load.cljc
@@ -91,6 +91,7 @@
           (reset! env* (handle-require-libspec-env ctx env cnn the-loaded-ns lib opts))))
       (if-let [load-fn (:load-fn env)]
         (if-let [{:keys [:file :source]} (load-fn {:namespace lib
+                                                   :opts opts
                                                    :reload (or reload reload-all)})]
           (do
             (let [ctx (-> ctx


### PR DESCRIPTION
Allows to pass options like `:as` from the require call, e.g. `(require '[lib :as lib])`, to `load-fn`.