### PR TITLE
feat: treat doseq and for as macro

### DIFF
--- a/src/sci/impl/analyzer.cljc
+++ b/src/sci/impl/analyzer.cljc
@@ -5,11 +5,9 @@
    [clojure.string :as str]
    #?(:cljs [goog.object :as gobj])
    [sci.impl.destructure :refer [destructure]]
-   [sci.impl.doseq-macro :refer [expand-doseq]]
    [sci.impl.evaluator :as eval]
    #?(:cljs [sci.impl.faster :as faster])
    [sci.impl.fns :as fns]
-   [sci.impl.for-macro :refer [expand-for]]
    [sci.impl.interop :as interop]
    [sci.impl.load :as load]
    [sci.impl.records :as records]
@@ -1116,11 +1114,6 @@
                         ;; TODO: implement as normal macro in namespaces.cljc
                         loop (expand-loop ctx expr)
                         lazy-seq (analyze-lazy-seq ctx expr)
-                        for (let [res (expand-for ctx expr)]
-                              (if (:sci.impl/macroexpanding ctx)
-                                res
-                                (analyze ctx res)))
-                        doseq (analyze ctx (expand-doseq ctx expr))
                         if (return-if ctx expr)
                         case (analyze-case ctx expr)
                         try (analyze-try ctx expr)

--- a/src/sci/impl/doseq_macro.cljc
+++ b/src/sci/impl/doseq_macro.cljc
@@ -13,7 +13,7 @@
                 "doseq requires an even number of forms in binding vector"))))
 
 (defn expand-doseq
-  [_ [_ seq-exprs & body]]
+  [expr _ seq-exprs & body]
   (assert-args seq-exprs body)
   (let [step (fn step [recform exprs]
                (if-not exprs

--- a/src/sci/impl/for_macro.cljc
+++ b/src/sci/impl/for_macro.cljc
@@ -19,7 +19,7 @@
 
 ;; see clojurescript core.cljc defmacro for
 (defn expand-for
-  [_ [_ seq-exprs body-expr :as expr]]
+  [expr _ seq-exprs body-expr]
   (assert-args expr seq-exprs body-expr)
   (let [to-groups (fn [seq-exprs]
                     (reduce (fn [groups [k v]]

--- a/src/sci/impl/namespaces.cljc
+++ b/src/sci/impl/namespaces.cljc
@@ -18,6 +18,8 @@
    [sci.impl.hierarchies :as hierarchies]
    [sci.impl.io :as io]
    [sci.impl.macros :as macros]
+   [sci.impl.for-macro :as for-macro]
+   [sci.impl.doseq-macro :as doseq-macro]
    [sci.impl.multimethods :as mm]
    [sci.impl.parser :as parser]
    [sci.impl.protocols :as protocols]
@@ -1005,6 +1007,7 @@
    'disj! (copy-core-var disj!)
    'doall (copy-core-var doall)
    'dorun (copy-core-var dorun)
+   'doseq   (macrofy 'doseq doseq-macro/expand-doseq)
    'dotimes (macrofy 'dotimes dotimes*)
    'doto (macrofy 'doto doto*)
    'double (copy-core-var double)
@@ -1044,6 +1047,7 @@
    'frequencies (copy-core-var frequencies)
    'float (copy-core-var float)
    'fn? (copy-core-var fn?)
+   'for (macrofy 'for for-macro/expand-for)
    'force (copy-core-var force)
    'get (copy-core-var get)
    'get-thread-binding-frame-impl (core-var 'get-thread-binding-frame-impl vars/get-thread-binding-frame)

--- a/src/sci/impl/utils.cljc
+++ b/src/sci/impl/utils.cljc
@@ -190,7 +190,7 @@
 
 (def ana-macros
   '#{do if and or let fn fn* def defn
-     comment loop lazy-seq for doseq case try defmacro
+     comment loop lazy-seq case try defmacro
      declare expand-dot* expand-constructor new . import in-ns ns var
      set! resolve #_#_macroexpand-1 macroexpand})
 

--- a/test/sci/core_test.cljc
+++ b/test/sci/core_test.cljc
@@ -355,6 +355,10 @@
   (is (thrown-with-msg? #?(:clj Exception :cljs js/Error)
                         #"allowed"
                         (tu/eval* "(clojure.core/inc 1)" {:deny '[clojure.core/inc]})))
+  (testing "for/doseq are macroexpanded properly"
+    (is (= 'loop (first (tu/eval* "(macroexpand '(doseq [i [1 2 3]] nil))" {}))))
+    (is (= #?(:clj 'clojure.core/let :cljs 'cljs.core/let)
+           (first (tu/eval* "(macroexpand '(for [i [1 2 3]] i))" {})))))
   (testing "for/doseq/dotimes use loop in a safe manner, so `{:deny '[loop recur]}` should not forbid it, see #141"
     (is '(1 2 3) (tu/eval* "(for [i [1 2 3] j [4 5 6]] [i j])" {:deny '[loop recur]}))
     (is (nil? (tu/eval* "(doseq [i [1 2 3]] i)" {:deny '[loop recur]})))


### PR DESCRIPTION
Currently, `doseq` and `for` are treated as special forms, however, these should be macros.

See related SO question: https://stackoverflow.com/questions/70235356/macroexpand-doseq-in-babashka-vs-in-clojure