### PR TITLE
feat: macros come from clojure.core

### DIFF
--- a/src/sci/impl/utils.cljc
+++ b/src/sci/impl/utils.cljc
@@ -189,7 +189,7 @@
        (cons run (split-when pred (lazy-seq (drop (count run) s))))))))
 
 (def ana-macros
-  '#{do if and or let fn fn* def defn
+  '#{do if let fn fn* def defn
      comment loop lazy-seq case try defmacro
      declare expand-dot* expand-constructor new . import in-ns ns var
      set! resolve #_#_macroexpand-1 macroexpand})


### PR DESCRIPTION
Changes:

## 1. (and) and (or) macros are not special forms any more

At the moment, the `and` and `or` macros are handled as special forms with custom implementation, and macroexpansion does not work for them.

## 2. Remove custom implementation of macros

We can reuse the implementation of some macros from `clojure.core` (and `cljs.core`) so the source code size of Sci can be reduced.

The `copy-var` helper function needs to be modified in order to let it support taking value of macro.

The following macros are affected (in order of appearance): `->`, `->>`, `as->`, `comment`, `and`, `cond->`, `cond->>`, `condp`, `doto`, `if-let`, `if-some`, `if-not`, `or`, `some->`, `some->>`,`when-first`, `when-let`, `when-some`, `when`, `when-not`, `while`.
