### PR TITLE
Get from namespaces to support non-symbol requires

### DIFF
--- a/src/sci/impl/resolve.cljc
+++ b/src/sci/impl/resolve.cljc
@@ -53,7 +53,7 @@
           (or (some-> env :namespaces (get 'clojure.core) (find sym-name))
               (when-let [v (when call? (get ana-macros sym-name))]
                 [sym v])))
-        (or (some-> env :namespaces sym-ns (find sym-name))
+        (or (some-> env :namespaces (get sym-ns) (find sym-name))
             (when-not only-var?
                  (when-let [clazz (interop/resolve-class ctx sym-ns)]
                    [sym (if call?


### PR DESCRIPTION
When using sci in a ClojureScript context, it is common to use the
following syntax:

(ns my-app (:require ["react" :as react]))

This denotes a javascript dependency, usually from npm. By using an
explicit `get`, it allow npm dependencies to participate in the name
resolution algorithm.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/sci/blob/master/doc/dev.md).

- [x] This PR correponds to an [issue with a clear problem statement](https://github.com/babashka/sci/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

#645