### PR TITLE
Add `to-array-2d`, `aclone`, `reduce` and `amap`

### DIFF
--- a/reflection.json
+++ b/reflection.json
@@ -92,5 +92,11 @@
   }
   ,
   {"name": "java.lang.reflect.AccessibleObject",
-   "methods" : [{"name":"canAccess"}]}
+   "methods" : [{"name":"canAccess"}]},
+
+  {"name": "clojure.lang.RT",
+   "methods": [
+     {"name": "aget"},
+     {"name": "aclone"}
+   ]}
 ]

--- a/src/sci/impl/namespaces.cljc
+++ b/src/sci/impl/namespaces.cljc
@@ -291,6 +291,23 @@
    `(when-not ~x
       (throw (#?(:clj AssertionError. :cljs js/Error.) (str "Assert failed: " ~message "\n" (pr-str '~x)))))))
 
+(defn areduce* [_ _ a idx ret init expr]
+  `(let [a# ~a l# (alength a#)]
+     (loop  [~idx 0 ~ret ~init]
+       (if (< ~idx l#)
+         (recur (unchecked-inc-int ~idx) ~expr)
+         ~ret))))
+
+(defn amap* [_ _ a idx ret expr]
+  `(let [a# ~a l# (alength a#)
+         ~ret (aclone a#)]
+     (loop  [~idx 0]
+       (if (< ~idx  l#)
+         (do
+           (aset ~ret ~idx ~expr)
+           (recur (unchecked-inc ~idx)))
+         ~ret))))
+
 (defn with-open*
   [_ _ bindings & body]
   (cond
@@ -903,11 +920,13 @@
    'comment (macrofy 'comment comment*)
    'add-watch (copy-core-var add-watch)
    'remove-watch (copy-core-var remove-watch)
+   'aclone (copy-core-var aclone)
    'aget (copy-core-var aget)
    'alias (core-var 'alias sci-alias true)
    'all-ns (core-var 'all-ns sci-all-ns true)
    'alter-meta! (copy-core-var alter-meta!)
    'alter-var-root (copy-core-var vars/alter-var-root)
+   'amap (macrofy 'amap amap*)
    'ancestors (core-var 'ancestors hierarchies/ancestors* true)
    'aset (copy-core-var aset)
    #?@(:clj ['aset-boolean (copy-core-var aset-boolean)
@@ -924,6 +943,7 @@
                :cljs (copy-core-var alength))
    'any? (copy-core-var any?)
    'apply (copy-core-var apply)
+   'areduce (macrofy 'areduce areduce*)
    'array-map (copy-core-var array-map)
    'assert (macrofy 'assert assert*)
    'assoc (copy-core-var assoc)
@@ -1268,6 +1288,7 @@
             :cljs (copy-var type clojure-core-ns))
    'true? (copy-core-var true?)
    'to-array (copy-core-var to-array)
+   'to-array-2d (copy-core-var to-array-2d)
    'update (copy-core-var update)
    'update-in (copy-core-var update-in)
    'uri? (copy-core-var uri?)

--- a/test/sci/core_test.cljc
+++ b/test/sci/core_test.cljc
@@ -1234,10 +1234,39 @@
   (is (= 2 (sci/eval-string
             "(def v (volatile! 1)) (vswap! v inc) @v"))))
 
+(deftest to-array-2d-test
+  (let [resulting-array (eval* "(to-array-2d [[1 2][3 4]])")]
+    (is (= 2 (alength resulting-array)))
+    (is (= (type (object-array 1)) (type (aget resulting-array 0))))))
+
+(deftest aclone-test
+  (let [[a b] (eval* "(let [a (into-array [1 2 3])
+                            b (aclone a)]
+                        [a b])")]
+    (is (not= a b))
+    (is (= (alength a) (alength b)))
+    (is (= (vec a) (vec b)))))
+
+(deftest areduce-test
+  (is (= 6.0 (eval* "(defn asum [xs]
+                        (areduce xs i ret (float 0)
+                                 (+ ret (aget xs i))))
+                     (asum (into-array [1.0 2.0 3.0]))"))))
+
+(deftest amap-test
+  (let [mapped-array
+        (eval* "(def an-array (into-array (range 5)))
+                (amap an-array
+                      idx
+                      ret
+                      (+ (int 1)
+                         (aget an-array idx)))")]
+    (is (= [1 2 3 4 5] (vec mapped-array)))))
+
 ;;;; Scratch
 
 (comment
   (eval* 1 '(inc *in*))
   (test-difference "foo" "[10 10]" 0 10)
-  (test-difference "rand" #(rand) 0 10)
-  )
+  (test-difference "rand" #(rand) 0 10))
+


### PR DESCRIPTION
This PR adds `to-array-2d`, `aclone`, `reduce` and `amap`, together with tests. 

Tests for JS and JVM work.
I can't compile and run the tests for native with `script/compile` though. (using GraalVM 21.3.0)
Can you run the tests and/or tell me what could be the problem? 




Resolves: https://github.com/babashka/sci/issues/649


Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/sci/blob/master/doc/dev.md).

- [x] This PR correponds to an [issue with a clear problem statement](https://github.com/babashka/sci/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR correponds to an [issue with a clear problem statement](https://github.com/babashka/sci/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/sci/blob/master/doc/dev.md#tests) to prevent against future regressions
