### PR TITLE
Add pop! to vars to copy from clojure core

### DIFF
--- a/src/sci/impl/namespaces.cljc
+++ b/src/sci/impl/namespaces.cljc
@@ -1176,6 +1176,7 @@
    'parents (core-var 'parents hierarchies/parents* true)
    'peek (copy-core-var peek)
    'pop (copy-core-var pop)
+   'pop! (copy-core-var pop!)
    'pop-thread-bindings (copy-core-var vars/pop-thread-bindings)
    'pos? (copy-core-var pos?)
    'pos-int? (copy-core-var pos-int?)


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [ ] I have read the [developer documentation](https://github.com/babashka/sci/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/sci/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/sci/blob/master/doc/dev.md#tests) to prevent against future regressions

----
I noticed that `pop!` doesn't work in Babashka so I made this pull request.
I didn't make an issue but I read [this slack archive](https://clojurians-log.clojureverse.org/babashka/2021-02-25/1614260499.085500) and [this pull request](https://github.com/babashka/sci/pull/536).




