### PR TITLE
add :name to meta when using copy-ns

### DIFF
--- a/src/sci/core.cljc
+++ b/src/sci/core.cljc
@@ -302,8 +302,8 @@
   (reduce (fn [ns-map [var-name var]]
             (let [m (:meta var)]
               (assoc ns-map var-name
-                     (new-var (symbol var-name) (:val var)
-                              (assoc m :ns sci-ns :name (symbol var-name))))))
+                     (new-var var-name (:val var)
+                              (assoc m :ns sci-ns :name var-name)))))
           {}
           ns-publics-map))
 

--- a/src/sci/core.cljc
+++ b/src/sci/core.cljc
@@ -303,7 +303,7 @@
             (let [m (:meta var)]
               (assoc ns-map var-name
                      (new-var (symbol var-name) (:val var)
-                              (assoc m :ns sci-ns)))))
+                              (assoc m :ns sci-ns :name (symbol var-name))))))
           {}
           ns-publics-map))
 

--- a/test/sci/core_test.cljc
+++ b/test/sci/core_test.cljc
@@ -1340,7 +1340,7 @@
   (testing "copy-ns default meta includes name"
     (let [sci-ns (sci/copy-ns sci.copy-ns-test-ns
                    (sci/create-ns 'sci.copy-ns-test-ns))]
-      (is (every? (fn [[var-name meta]] (= var-name (:name meta)))
+      (is (every? (fn [[var-name meta]] (and (symbol? var-name) (= var-name (:name meta))))
             (map (fn [[name var]] (vector name (meta var))) sci-ns))))))
 
 (deftest vswap-test

--- a/test/sci/core_test.cljc
+++ b/test/sci/core_test.cljc
@@ -1336,6 +1336,13 @@
     (is (:copy-this (meta (get sci-ns 'foo))))
     (is (:awesome-meta (meta (get sci-ns 'baz))))))
 
+(deftest copy-ns-default-meta-test
+  (testing "copy-ns default meta includes name"
+    (let [sci-ns (sci/copy-ns sci.copy-ns-test-ns
+                   (sci/create-ns 'sci.copy-ns-test-ns))]
+      (is (every? (fn [[var-name meta]] (= var-name (:name meta)))
+            (map (fn [[name var]] (vector name (meta var))) sci-ns))))))
+
 (deftest vswap-test
   (is (= 2 (sci/eval-string
             "(def v (volatile! 1)) (vswap! v inc) @v"))))


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/sci/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/sci/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/sci/blob/master/doc/dev.md#tests) to prevent against future regressions

closes #697 

I first tried this by just adding `:name` to the default meta for copy-ns, but it looks like the var analysis map that the cljs analyzer returns doesn't have `:name` meta. I then added this kind of ugly 'assoc the name on to the meta map' in the cljs conditional, but I think this is probably the simplest approach.
