### PR TITLE
use helper functions for var creation

### DIFF
--- a/src/sci/addons/future.clj
+++ b/src/sci/addons/future.clj
@@ -1,14 +1,13 @@
 (ns sci.addons.future
   {:no-doc true}
   (:refer-clojure :exclude [future pmap])
-  (:require [sci.impl.namespaces :refer [copy-core-var core-var]])
+  (:require [sci.impl.namespaces :refer [copy-core-var core-var macrofy]])
   (:require [sci.impl.vars :as vars]))
 
-(def future* ^{:sci/macro true
-               :ns vars/clojure-core-ns}
-  (fn [_ _ & body]
-    `(let [f# (~'binding-conveyor-fn (fn [] ~@body))]
-       (~'future-call f#))))
+(def future* (macrofy 'future
+               (fn [_ _ & body]
+                 `(let [f# (~'binding-conveyor-fn (fn [] ~@body))]
+                    (~'future-call f#)))))
 
 (defmacro future**
   "Like clojure.core/future but also conveys sci bindings to the thread."

--- a/src/sci/impl/namespaces.cljc
+++ b/src/sci/impl/namespaces.cljc
@@ -762,17 +762,14 @@
 
 ;;;; REPL vars
 
-(def *1 (vars/->SciVar nil '*1 {:ns clojure-core-ns
-                                :dynamic true} false))
+(def *1 (vars/dynamic-var '*1 nil {:ns clojure-core-ns}))
 
-(def *2 (vars/->SciVar nil '*2 {:ns clojure-core-ns
-                                :dynamic true} false))
+(def *2 (vars/dynamic-var '*2 nil {:ns clojure-core-ns}))
 
-(def *3 (vars/->SciVar nil '*3 {:ns clojure-core-ns
-                                :dynamic true} false))
+(def *3 (vars/dynamic-var '*3 nil {:ns clojure-core-ns}))
 
-(def *e (vars/->SciVar nil '*e {:ns clojure-core-ns
-                                :dynamic true} false))
+(def *e (vars/dynamic-var '*e nil {:ns clojure-core-ns}))
+
 
 ;;;; Patch for CLJS type
 
@@ -979,9 +976,9 @@
              'aset-int (copy-core-var aset-int)
              'aset-long (copy-core-var aset-long)
              'aset-short (copy-core-var aset-short)])
-   'alength #?(:clj (vars/->SciVar (fn [arr]
+   'alength #?(:clj (vars/new-var 'alength (fn [arr]
                                      (java.lang.reflect.Array/getLength arr))
-                                   'alength {:ns clojure-core-ns} false)
+                                    {:ns clojure-core-ns})
                :cljs (copy-core-var alength))
    'any? (copy-core-var any?)
    'apply (copy-core-var apply)
@@ -1367,7 +1364,7 @@
    'unchecked-short (copy-core-var unchecked-short)
    #?@(:cljs ['undefined? (copy-core-var undefined?)])
    'underive (core-var 'underive hierarchies/underive* true)
-   'unquote (doto (vars/->SciVar nil 'clojure.core/unquote {:ns clojure-core-ns} false)
+   'unquote (doto (vars/new-var 'clojure.core/unquote nil {:ns clojure-core-ns})
               (vars/unbind))
    'use (core-var 'use use true)
    'val (copy-core-var val)

--- a/src/sci/impl/opts.cljc
+++ b/src/sci/impl/opts.cljc
@@ -31,8 +31,8 @@
                      namespaces (-> namespaces
                                     (update 'user assoc :aliases aliases)
                                     (update 'clojure.core assoc 'global-hierarchy
-                                            (vars/->SciVar (make-hierarchy) 'global-hierarchy
-                                              {:ns vars/clojure-core-ns} false)))
+                                            (vars/new-var 'global-hierarchy (make-hierarchy) 
+                                              {:ns vars/clojure-core-ns})))
                      imports (if-let [env-imports (:imports env)]
                                (merge env-imports imports)
                                imports)]

--- a/src/sci/impl/parser.cljc
+++ b/src/sci/impl/parser.cljc
@@ -13,11 +13,11 @@
 (def ^:const eof :sci.impl.parser.edamame/eof)
 
 (def read-eval
-  (vars/new-var '*read-eval true {:ns vars/clojure-core-ns
+  (vars/new-var '*read-eval* true {:ns vars/clojure-core-ns
                                   :dynamic true}))
 
 (def data-readers
-  (vars/new-var '*default-data-reader-fn* {}
+  (vars/new-var '*data-readers* {}
                 {:ns vars/clojure-core-ns
                  :dynamic true}))
 


### PR DESCRIPTION
In preparation for a change to put :name metadata on vars created
via new-var et al (instead of using the constructor), this change
uses the helper functions to create some vars that were previously
created using the constructor, plus:

- future.clj - use macrofy to supply a different var name
- parser.cljc - correct a couple of var names

before:
```clojure
user=> #'*read-eval*
#'*read-eval
user=> #'*data-readers*
#'*default-data-reader-fn*
user=> #'future
#object[sci.addons.future$future_STAR_ 0x16c6f0b3 "sci.addons.future$future_STAR_@16c6f0b3"]
```

after:
```clojure
user=> #'*read-eval*
#'*read-eval*
user=> #'*data-readers*
#'*data-readers*
user=> #'future
#'future
```



Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/sci/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/sci/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
These are preliminary changes to facilitate progress on https://github.com/babashka/babashka/issues/1223 (in the interest of small PRs that fit in my head)

- [x] This PR contains a [test](https://github.com/babashka/sci/blob/master/doc/dev.md#tests) to prevent against future regressions
There are no real functional changes here, so existing tests serve as the regression test