### PR TITLE
add :name metadata via helper functions and use metadata for var names

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ corresponding SCI vars, you can use `ns-publics` in Clojure and the following AP
 
 - `sci/create-ns`: creates an object that identifies a SCI namespace and carries the metadata of a SCI namespaces
 - `sci/copy-var`: macro that copies a Clojure var to a SCI namespace (created through `sci/create-ns`). Automatically converts dynamic vars and macros. Captures docstrings and arglists.
+- `sci/copy-var-with-diff-name`: same as `copy-var`, but takes an additional argument, a symbol, that will be the var's name.
 
 E.g. given the following Clojure namespace:
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ corresponding SCI vars, you can use `ns-publics` in Clojure and the following AP
 
 - `sci/create-ns`: creates an object that identifies a SCI namespace and carries the metadata of a SCI namespaces
 - `sci/copy-var`: macro that copies a Clojure var to a SCI namespace (created through `sci/create-ns`). Automatically converts dynamic vars and macros. Captures docstrings and arglists.
-- `sci/copy-var-with-diff-name`: same as `copy-var`, but takes an additional argument, a symbol, that will be the var's name.
+- `sci/copy-and-rename-var`: same as `copy-var`, but takes an additional argument, a symbol (without the namespace), that will be the var's name.
 
 E.g. given the following Clojure namespace:
 
@@ -231,6 +231,8 @@ E.g. given the following Clojure namespace:
 
 (defn times-two [x]
   (* x 2))
+  
+(defn silly-name [x] (* x x))
 ```
 
 you can re-create that namespace in a SCI context like this:
@@ -241,7 +243,8 @@ you can re-create that namespace in a SCI context like this:
 (def fns (sci/create-ns 'foobar-ns nil))
 
 (def foobar-ns {'do-twice (sci/copy-var foobar/do-twice fns)
-                'times-two (sci/copy-var foobar/times-two fns)})
+                'times-two (sci/copy-var foobar/times-two fns)
+                'better-name (sci/copy-and-rename-var foobar/silly-name fns 'better-name)})
 
 (def ctx (sci/init {:namespaces {'foobar foobar-ns}}))
 
@@ -253,6 +256,9 @@ nil
 
 (sci/eval-string* ctx "(foobar/times-two 2)")
 4
+
+(sci/eval-string* ctx "(foobar/better-name 4)")
+16
 ```
 
 To copy an entire namespace without enumerating all vars explicitly with

--- a/README.md
+++ b/README.md
@@ -219,8 +219,8 @@ To copy the public vars of a Clojure namespace and to reify the Clojure vars int
 corresponding SCI vars, you can use `ns-publics` in Clojure and the following API functions:
 
 - `sci/create-ns`: creates an object that identifies a SCI namespace and carries the metadata of a SCI namespaces
-- `sci/copy-var`: macro that copies a Clojure var to a SCI namespace (created through `sci/create-ns`). Automatically converts dynamic vars and macros. Captures docstrings and arglists.
-- `sci/copy-and-rename-var`: same as `copy-var`, but takes an additional argument, a symbol (without the namespace), that will be the var's name.
+- `sci/copy-var`: macro that copies a Clojure var to a SCI namespace (created through `sci/create-ns`). Automatically converts dynamic vars and macros. Captures docstrings and arglists. Takes an optional third arguments of an options map, which currently supports `:name` to set the name of the copied var. 
+
 
 E.g. given the following Clojure namespace:
 
@@ -244,7 +244,7 @@ you can re-create that namespace in a SCI context like this:
 
 (def foobar-ns {'do-twice (sci/copy-var foobar/do-twice fns)
                 'times-two (sci/copy-var foobar/times-two fns)
-                'better-name (sci/copy-and-rename-var foobar/silly-name fns 'better-name)})
+                'better-name (sci/copy-var foobar/silly-name fns {:name 'better-name})})
 
 (def ctx (sci/init {:namespaces {'foobar foobar-ns}}))
 

--- a/script/test/native
+++ b/script/test/native
@@ -4,6 +4,3 @@ set -eo pipefail
 
 echo 'Running native test'
 SCI_TEST_ENV="native" lein test
-
-echo "Testing native performance"
-SCI_TEST_ENV="native" SCI_TEST_PERFORMANCE=true lein with-profiles +clojure-1.10.2-alpha1 test :only sci.performance-test

--- a/src/sci/core.cljc
+++ b/src/sci/core.cljc
@@ -26,14 +26,14 @@
   ([name] (doto (new-var name nil nil)
             (vars/unbind)))
   ([name init-val] (new-var name init-val (meta name)))
-  ([name init-val meta] (sci.impl.vars.SciVar. init-val name meta false)))
+  ([name init-val meta] (sci.impl.vars.SciVar. init-val name (assoc meta :name (utils/unqualify-symbol name)) false)))
 
 (defn new-dynamic-var
   "Same as new-var but adds :dynamic true to meta."
   ([name] (doto (new-dynamic-var name nil nil)
             (vars/unbind)))
   ([name init-val] (new-dynamic-var name init-val (meta name)))
-  ([name init-val meta] (sci.impl.vars.SciVar. init-val name (assoc meta :dynamic true) false)))
+  ([name init-val meta] (sci.impl.vars.SciVar. init-val name (assoc meta :dynamic true :name (utils/unqualify-symbol name)) false)))
 
 (defn set!
   "Establish thread local binding of dynamic var"
@@ -47,7 +47,7 @@
   ([name init-val meta] (sci.impl.vars.SciVar.
                          (vary-meta init-val
                                     assoc :sci/macro true)
-                         name (assoc meta :macro true) false)))
+                         name (assoc meta :macro true :name (utils/unqualify-symbol name)) false)))
 
 (defmacro copy-var
   "Copies contents from var `sym` to a new sci var. The value `ns` is an

--- a/src/sci/core.cljc
+++ b/src/sci/core.cljc
@@ -16,8 +16,8 @@
    [sci.impl.utils :as utils]
    [sci.impl.vars :as vars])
   #?(:cljs (:require-macros
-            [sci.core :refer [with-bindings with-out-str copy-var copy-ns
-                              require-cljs-analyzer-api]])))
+            [sci.core :refer [with-bindings with-out-str copy-var copy-var-with-diff-name 
+                              copy-ns require-cljs-analyzer-api]])))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -49,16 +49,16 @@
                                     assoc :sci/macro true)
                          name (assoc meta :macro true :name (utils/unqualify-symbol name)) false)))
 
-(defmacro copy-var
+(defmacro copy-var-with-diff-name
   "Copies contents from var `sym` to a new sci var. The value `ns` is an
   object created with `sci.core/create-ns`."
-  ([sym ns]
+  ([sym ns new-name]
    `(let [ns# ~ns
           var# (var ~sym)
           val# (deref var#)
           m# (-> var# meta)
           ns-name# (vars/getName ns#)
-          name# (:name m#)
+          name# (or ~new-name (:name m#))
           name-sym# (symbol (str ns-name#) (str name#))
           new-m# {:doc (:doc m#)
                   :name name#
@@ -69,6 +69,12 @@
             (:macro m#)
             (new-macro-var name# val# new-m#)
             :else (new-var name# val# new-m#)))))
+
+(defmacro copy-var
+  "Copies contents from var `sym` to a new sci var. The value `ns` is an
+  object created with `sci.core/create-ns`."
+  ([sym ns]
+   `(copy-var-with-diff-name ~sym ~ns nil)))
 
 (macros/deftime
   (defmacro with-bindings

--- a/src/sci/core.cljc
+++ b/src/sci/core.cljc
@@ -16,7 +16,7 @@
    [sci.impl.utils :as utils]
    [sci.impl.vars :as vars])
   #?(:cljs (:require-macros
-            [sci.core :refer [with-bindings with-out-str copy-var copy-and-rename-var 
+            [sci.core :refer [with-bindings with-out-str copy-var 
                               copy-ns require-cljs-analyzer-api]])))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -49,17 +49,18 @@
                                     assoc :sci/macro true)
                          name (assoc meta :macro true :name (utils/unqualify-symbol name)) false)))
 
-(defmacro copy-and-rename-var
+(defmacro copy-var
   "Copies contents from var `sym` to a new sci var. The value `ns` is an
-  object created with `sci.core/create-ns`."
-  ([sym ns new-name]
+  object created with `sci.core/create-ns`. If new-name is supplied, the 
+  copied var will be named new-name."
+  ([sym ns]
+   `(copy-var ~sym ~ns nil))
+  ([sym ns opts]
    `(let [ns# ~ns
           var# (var ~sym)
           val# (deref var#)
           m# (-> var# meta)
-          ns-name# (vars/getName ns#)
-          name# (or ~new-name (:name m#))
-          name-sym# (symbol (str ns-name#) (str name#))
+          name# (or (:name ~opts) (:name m#))
           new-m# {:doc (:doc m#)
                   :name name#
                   :arglists (:arglists m#)
@@ -69,12 +70,6 @@
             (:macro m#)
             (new-macro-var name# val# new-m#)
             :else (new-var name# val# new-m#)))))
-
-(defmacro copy-var
-  "Copies contents from var `sym` to a new sci var. The value `ns` is an
-  object created with `sci.core/create-ns`."
-  ([sym ns]
-   `(copy-and-rename-var ~sym ~ns nil)))
 
 (macros/deftime
   (defmacro with-bindings

--- a/src/sci/core.cljc
+++ b/src/sci/core.cljc
@@ -16,7 +16,7 @@
    [sci.impl.utils :as utils]
    [sci.impl.vars :as vars])
   #?(:cljs (:require-macros
-            [sci.core :refer [with-bindings with-out-str copy-var copy-var-with-diff-name 
+            [sci.core :refer [with-bindings with-out-str copy-var copy-and-rename-var 
                               copy-ns require-cljs-analyzer-api]])))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -49,7 +49,7 @@
                                     assoc :sci/macro true)
                          name (assoc meta :macro true :name (utils/unqualify-symbol name)) false)))
 
-(defmacro copy-var-with-diff-name
+(defmacro copy-and-rename-var
   "Copies contents from var `sym` to a new sci var. The value `ns` is an
   object created with `sci.core/create-ns`."
   ([sym ns new-name]
@@ -74,7 +74,7 @@
   "Copies contents from var `sym` to a new sci var. The value `ns` is an
   object created with `sci.core/create-ns`."
   ([sym ns]
-   `(copy-var-with-diff-name ~sym ~ns nil)))
+   `(copy-and-rename-var ~sym ~ns nil)))
 
 (macros/deftime
   (defmacro with-bindings

--- a/src/sci/impl/namespaces.cljc
+++ b/src/sci/impl/namespaces.cljc
@@ -31,7 +31,7 @@
    [sci.impl.types :as types]
    [sci.impl.utils :as utils :refer [eval needs-ctx]]
    [sci.impl.vars :as vars])
-  #?(:cljs (:require-macros [sci.impl.namespaces :refer [copy-var copy-core-var copy-and-rename-var]])))
+  #?(:cljs (:require-macros [sci.impl.namespaces :refer [copy-var copy-core-var]])))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -57,31 +57,27 @@
       #?(:clj
        (binding [*out* *err*]
          (println "SCI: eliding vars.")))
-      (defmacro copy-and-rename-var [sym _ns _new-name] sym)
       (defmacro copy-var [sym _ns] sym)
       (defmacro copy-core-var [sym] sym))
     (do
-      (defmacro copy-and-rename-var
-        ([sym ns new-name]
-         `(let [ns# ~ns
-                m# (-> (var ~sym) meta)
-                ns-name# (vars/getName ns#)
-                name# (or ~new-name (:name m#))
-                name-sym# (symbol (str ns-name#) (str name#))
-                val# ~sym]
-            (vars/->SciVar val# name-sym# (cond->
-                                              {:doc (:doc m#)
-                                               :name name#
-                                               :arglists (:arglists m#)
-                                               :ns ns#
-                                               :sci/built-in true}
-                                            (and (identical? clojure-core-ns ns#)
-                                                 (contains? inlined-vars name#))
-                                            (assoc :sci.impl/inlined val#))
-                           false))))
       (defmacro copy-var
         ([sym ns]
-         `(copy-and-rename-var ~sym ~ns nil)))
+         `(copy-var ~sym ~ns nil))
+        ([sym ns opts]
+         `(let [ns# ~ns
+                m# (-> (var ~sym) meta)
+                name# (or (:name ~opts) (:name m#))
+                val# ~sym]
+            (vars/->SciVar val# name# (cond->
+                                            {:doc (:doc m#)
+                                             :name name#
+                                             :arglists (:arglists m#)
+                                             :ns ns#
+                                             :sci/built-in true}
+                                            (and (identical? clojure-core-ns ns#)
+                                              (contains? inlined-vars name#))
+                                            (assoc :sci.impl/inlined val#))
+              false))))
       (defmacro copy-core-var
         ([sym]
          `(copy-var ~sym clojure-core-ns))))))
@@ -1005,7 +1001,7 @@
    'bit-shift-left (copy-core-var bit-shift-left)
    'bit-shift-right (copy-core-var bit-shift-right)
    'bit-xor (copy-core-var bit-xor)
-   'bound? (copy-and-rename-var sci-bound? clojure-core-ns 'bound?)
+   'bound? (copy-var sci-bound? clojure-core-ns {:name 'bound?})
    'boolean (copy-core-var boolean)
    'boolean? (copy-core-var boolean?)
    'booleans (copy-core-var booleans)
@@ -1303,10 +1299,10 @@
    ;; #?@(:cljs ['-js-this -js-this
    ;;            'this-as (macrofy 'this-as this-as clojure-core-ns)])
    'test (copy-core-var test)
-   'thread-bound? (copy-and-rename-var sci-thread-bound? clojure-core-ns 'thread-bound?)
+   'thread-bound? (copy-var sci-thread-bound? clojure-core-ns {:name 'thread-bound?})
    'subs (copy-core-var subs)
    #?@(:clj ['supers (copy-core-var supers)])
-   'symbol (copy-and-rename-var symbol* clojure-core-ns 'symbol)
+   'symbol (copy-var symbol* clojure-core-ns {:name 'symbol})
    'symbol? (copy-core-var symbol?)
    'special-symbol? (copy-core-var special-symbol?)
    'subvec (copy-core-var subvec)

--- a/src/sci/impl/namespaces.cljc
+++ b/src/sci/impl/namespaces.cljc
@@ -57,7 +57,9 @@
       #?(:clj
        (binding [*out* *err*]
          (println "SCI: eliding vars.")))
-      (defmacro copy-var [sym _ns] sym)
+      (defmacro copy-var
+        ([sym _ns] sym)
+        ([sym _ns _opts] sym))
       (defmacro copy-core-var [sym] sym))
     (do
       (defmacro copy-var

--- a/src/sci/impl/namespaces.cljc
+++ b/src/sci/impl/namespaces.cljc
@@ -31,7 +31,7 @@
    [sci.impl.types :as types]
    [sci.impl.utils :as utils :refer [eval needs-ctx]]
    [sci.impl.vars :as vars])
-  #?(:cljs (:require-macros [sci.impl.namespaces :refer [copy-var copy-core-var copy-var-with-diff-name]])))
+  #?(:cljs (:require-macros [sci.impl.namespaces :refer [copy-var copy-core-var copy-and-rename-var]])))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -57,11 +57,11 @@
       #?(:clj
        (binding [*out* *err*]
          (println "SCI: eliding vars.")))
-      (defmacro copy-var-with-diff-name [sym _ns _new-name] sym)
+      (defmacro copy-and-rename-var [sym _ns _new-name] sym)
       (defmacro copy-var [sym _ns] sym)
       (defmacro copy-core-var [sym] sym))
     (do
-      (defmacro copy-var-with-diff-name
+      (defmacro copy-and-rename-var
         ([sym ns new-name]
          `(let [ns# ~ns
                 m# (-> (var ~sym) meta)
@@ -81,7 +81,7 @@
                            false))))
       (defmacro copy-var
         ([sym ns]
-         `(copy-var-with-diff-name ~sym ~ns nil)))
+         `(copy-and-rename-var ~sym ~ns nil)))
       (defmacro copy-core-var
         ([sym]
          `(copy-var ~sym clojure-core-ns))))))
@@ -1005,7 +1005,7 @@
    'bit-shift-left (copy-core-var bit-shift-left)
    'bit-shift-right (copy-core-var bit-shift-right)
    'bit-xor (copy-core-var bit-xor)
-   'bound? (copy-var-with-diff-name sci-bound? clojure-core-ns 'bound?)
+   'bound? (copy-and-rename-var sci-bound? clojure-core-ns 'bound?)
    'boolean (copy-core-var boolean)
    'boolean? (copy-core-var boolean?)
    'booleans (copy-core-var booleans)
@@ -1303,10 +1303,10 @@
    ;; #?@(:cljs ['-js-this -js-this
    ;;            'this-as (macrofy 'this-as this-as clojure-core-ns)])
    'test (copy-core-var test)
-   'thread-bound? (copy-var-with-diff-name sci-thread-bound? clojure-core-ns 'thread-bound?)
+   'thread-bound? (copy-and-rename-var sci-thread-bound? clojure-core-ns 'thread-bound?)
    'subs (copy-core-var subs)
    #?@(:clj ['supers (copy-core-var supers)])
-   'symbol (copy-var-with-diff-name symbol* clojure-core-ns 'symbol)
+   'symbol (copy-and-rename-var symbol* clojure-core-ns 'symbol)
    'symbol? (copy-core-var symbol?)
    'special-symbol? (copy-core-var special-symbol?)
    'subvec (copy-core-var subvec)

--- a/src/sci/impl/utils.cljc
+++ b/src/sci/impl/utils.cljc
@@ -241,6 +241,8 @@
          :body [`(let ~lets
                    ~@body)]}))))
 
+(def unqualify-symbol vars/unqualify-symbol)
+
 (defn log [& xs]
   #?(:clj (.println System/err (str/join " " xs))
      :cljs (.log js/console (str/join " " xs))))

--- a/src/sci/impl/vars.cljc
+++ b/src/sci/impl/vars.cljc
@@ -242,7 +242,7 @@
 
 (deftype SciVar [#?(:clj ^:volatile-mutable root
                     :cljs ^:mutable root)
-                 _sym
+                 sym
                  #?(:clj ^:volatile-mutable meta
                     :cljs ^:mutable meta)
                  #?(:clj ^:volatile-mutable thread-bound
@@ -259,7 +259,12 @@
       (set! (.-root this) v)))
   (getRawRoot [this]
     root)
-  (toSymbol [this] (symbol (name (getName (:ns meta))) (name (:name meta))))
+  (toSymbol [this]
+    ; if we have at least a name from metadata, then build the symbol from that
+    (if-let [sym-name (some-> (:name meta) name)]
+      (symbol (some-> (:ns meta) getName name) sym-name)
+      ; otherwise, fall back to the symbol
+      sym))
   (isMacro [_]
     (or (:macro meta)
         (when-some [m (clojure.core/meta root)]

--- a/src/sci/impl/vars.cljc
+++ b/src/sci/impl/vars.cljc
@@ -252,7 +252,7 @@
      sci.lang.IVar)
   HasName
   (getName [this]
-    (:name meta))
+    (or (:name meta) sym))
   IVar
   (bindRoot [this v]
     (with-writeable-var this meta

--- a/test/sci/core_test.cljc
+++ b/test/sci/core_test.cljc
@@ -1393,6 +1393,26 @@
   (is (identical? [] (sci/eval-string "[]")))
   (is (identical? #{} (sci/eval-string "#{}"))))
 
+
+(deftest var-name-test
+  (testing "var name strings match their namespace and symbol"
+      (is (empty? (sci/eval-string "
+ (require '[clojure.string :as str])
+ (let [ns-maps  (->> (all-ns)
+                    (map (fn [nmspc] [(ns-name nmspc) (ns-publics nmspc)]))
+                    (into {}))] ; a map of { ns-name {symbol var, ...}}
+  (->>
+    (for [[ns-nm _] ns-maps
+        [sym vr]  (ns-maps ns-nm)
+        :let [{var-meta-ns :ns, var-meta-name :name} (meta vr)
+              var-meta-ns-name ((fnil ns-name (create-ns \"missing-ns\")) var-meta-ns)]]
+      ; build a seq of maps containing the ns/symbol from the ns and the ns/symbol from the var's metadata
+      {:actual-ns ns-nm :actual-ns-symbol sym :var-meta-ns var-meta-ns-name :var-meta-name var-meta-name})
+    ; remove the protocol/interface-ish vars whose metas don't really match  
+    (remove (fn [{:keys [var-meta-name]}]
+              (str/starts-with? (name var-meta-name) \"cljs.core.\")))
+    (filter (complement #(and (= (:actual-ns %) (:var-meta-ns %)) (= (:actual-ns-symbol %) (:var-meta-name %)))))))")))))
+
 ;;;; Scratch
 
 (comment

--- a/test/sci/impl/vars_test.cljc
+++ b/test/sci/impl/vars_test.cljc
@@ -1,0 +1,9 @@
+(ns sci.impl.vars-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [sci.impl.vars :as vars]))
+
+(deftest unqualify-symbol-test
+  (testing "passing a simple symbol returns the symbol"
+    (is (= 'foo (vars/unqualify-symbol 'foo))))
+  (testing "passing a namespaced symbol returns the symbol without the namespace"
+    (is (= 'foo (vars/unqualify-symbol 'some.random.ns/foo)))))


### PR DESCRIPTION
This PR got a little bigger than I wanted, but it includes some things that babashka will need for some var name cleanup.

**Background/problem statement**
The `sym` field on `SciVar`s sometimes contains a namespace, and sometimes doesn't. This can lead to unusual var name strings. In addition, some `SciVar`s currently don't get `:name` metadata (see https://github.com/babashka/babashka/issues/1223), which can lead to unexpected output from things like `doc` that use that metadata. Finally, some vars that get copied from clojure namespaces into sci namespaces are desired to have different names in sci, but copy-var always uses the name from the clojure namespace (on the var, not the sci namespace symbol). The anomalies that arise from this are primarily (entirely?) cosmetic in nature.

Examples (demonstrated using babashka for simplicity):
```clojure
; missing name
user=> (doc doc)
-------------------------
clojure.repl/
Macro
nil

; var name string representation is different from the symbol that refers to it
user=> (var thread-bound?)
#'clojure.core/sci-thread-bound?
```

**High-level description of main changes**
- In the `new-var` and family helper functions, assoc `:name` meta onto the meta of the var being created. In case the name passed to `new-var` contains a namespace, strip the namespace off the symbol that goes into the metadata.
- put `:ns` meta on vars being interned (in `sci-intern`), and use the helper function which will also add on the `:name` meta
- Use metadata for producing `SciVar`s symbol and toString and print-method and so on. As a fallback in case there's no `:name` metadata on the var (if a constructor was used without explicitly supplying the appropriate metadata), we can still use the `sym` field.
- There are some cases where we copy vars, but we'd like the target var to have a different name from the source var (this really only affects the metadata and string representations), so what is basically an additional arity has been to `copy-var`. Based on the note about self-hosted CLJS not handling multi-arity macros, I followed the pattern and added a different macro called `copy-and-rename-var` - I'm very open to changing that name (I've already changed it at least twice) based on preference. Because this goes along with `copy-var`, I've also added some documentation and an example to the readme.
- use that macro to rename the vars with different source names (e.g. `'thread-bound?` and `symbol`)
- add a test that confirms that all public vars (minus the protocol-ish ones) have ns and name metadata that matches the ns and symbol names from `(ns-publics)`

**Minor/ancillary changes**
- created some `SciVar`s for things that weren't `SciVar`s
- removed the test call for non-existent performance namespace

I've also run the babashka tests against these changes locally and couldn't find any problems - if this goes through, I'll have a follow on PR for babashka that uses `copy-and-rename-var` to match a handful of var names up with their symbol names.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/sci/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/sci/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/sci/blob/master/doc/dev.md#tests) to prevent against future regressions
