### PR TITLE
satisfies? finds protocols that have no methods

### DIFF
--- a/src/sci/impl/namespaces.cljc
+++ b/src/sci/impl/namespaces.cljc
@@ -1011,6 +1011,7 @@
    #?@(:clj ['proxy* (core-var 'proxy* proxy/proxy* true)
              'proxy (macrofy 'proxy proxy/proxy clojure-core-ns true)])
    'satisfies? (copy-core-var sci.impl.protocols/satisfies?)
+   'type->str (copy-core-var sci.impl.protocols/type->str)
    ;; end protocols
    ;; IDeref as protocol
    'deref (core-var 'deref core-protocols/deref*)

--- a/src/sci/impl/protocols.cljc
+++ b/src/sci/impl/protocols.cljc
@@ -2,7 +2,7 @@
   {:no-doc true}
   (:refer-clojure :exclude [defprotocol extend-protocol
                             extend extend-type reify satisfies?
-                            extends? implements?])
+                            extends? implements? type->str])
   (:require
    #?(:clj [sci.impl.interop :as interop])
    [sci.impl.deftype]
@@ -197,6 +197,10 @@
       'array 'js/Array
       'function 'js/Function
       'boolean 'js/Boolean}))
+
+(defn type->str
+  [t]
+  (str t))
 
 (defn extend-protocol [_ _ ctx protocol-name & impls]
   (let [impls (utils/split-when #(not (seq? %)) impls)

--- a/src/sci/impl/protocols.cljc
+++ b/src/sci/impl/protocols.cljc
@@ -217,7 +217,7 @@
                       `(do
                          (clojure.core/alter-var-root
                           (var ~protocol-name) update :satisfies (fnil conj #{})
-                          (symbol (str ~type)))
+                          (symbol (~'type->str ~type)))
                          ~@(process-methods ctx type meths pns extend-via-metadata))))
                   impls))]
     expansion))
@@ -235,7 +235,7 @@
                 `(do
                    (clojure.core/alter-var-root
                     (var ~proto) update :satisfies (fnil conj #{})
-                    (symbol (str ~atype)))
+                    (symbol (~'type->str ~atype)))
                    ~@(process-methods ctx atype meths pns extend-via-metadata)))) proto+meths))))
 
 ;; IAtom can be implemented as a protocol on reify and defrecords in sci
@@ -245,14 +245,7 @@
         (or #?(:clj (contains? sats (symbol "class java.lang.Object"))
                :cljs (contains? sats (symbol extend-default-val)))
             (when-let [t (types/type-impl obj)]
-              #_{:clj-kondo/ignore [:redundant-let]}
-              (let [t (cond
-                        #?(:clj (class? t))
-                        #?(:clj (symbol (.getName ^Class t)))
-                        (instance? sci.lang.Type t)
-                        (symbol (str t))
-                        :else t)]
-                (contains? sats t)))))
+              (contains? sats (symbol (type->str t))))))
       (boolean (some #(when-let [m (get-method % (types/type-impl obj))]
                         (let [ms (methods %)
                               default (get ms :default)]

--- a/test/sci/protocols_test.cljc
+++ b/test/sci/protocols_test.cljc
@@ -4,7 +4,8 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [sci.core :as sci]
-   [sci.test-utils :as tu]))
+   [sci.test-utils :as tu])
+  (:import [java.lang Long]))
 
 (deftest protocol-test
   (let [prog "
@@ -331,18 +332,25 @@
 (extend-protocol Marker Foo)
 (satisfies? Marker (->Foo))
 ")))
-  #?(:clj (is (true? (sci/binding [sci/out *out*](sci/eval-string "
-(defprotocol Marker)
-
+  (is (true?
+       (sci/binding [sci/out *out*]
+         (-> "(defprotocol Marker)
 (extend-type java.lang.Long Marker)
-(satisfies? Marker 1)
-" {:classes '{java.lang.Long java.lang.Long}})))))
-  #?(:clj (is (true? (sci/binding [sci/out *out*](sci/eval-string "
-(defprotocol Marker)
-
+(satisfies? Marker 1)"
+             #?(:cljs (str/replace "java.lang.Long" "number"))
+             (sci/eval-string
+              #?(:clj {:classes {'java.lang.Long java.lang.Long}}
+                 :cljs {:classes {'js #js {:Number js/Number}}}))))))
+  (is (true?
+       (sci/binding [sci/out *out*]
+         (-> "(defprotocol Marker)
 (extend-protocol Marker java.lang.Long)
-(satisfies? Marker 1)
-" {:classes '{java.lang.Long java.lang.Long}}))))))
+(satisfies? Marker 1)"
+             #?(:cljs (str/replace "java.lang.Long" "number"))
+             (sci/eval-string
+              #?(:clj {:classes {'java.lang.Long java.lang.Long}}
+                 :cljs {:classes {'js #js {:Number js/Number}}})))))))
+
 
 (deftest return-value-test
   (is (true? (eval* "(= 'P (defprotocol P))"))))

--- a/test/sci/protocols_test.cljc
+++ b/test/sci/protocols_test.cljc
@@ -5,7 +5,7 @@
    [clojure.test :refer [deftest is testing]]
    [sci.core :as sci]
    [sci.test-utils :as tu])
-  (:import [java.lang Long]))
+  #?(:clj (:import [java.lang Long])))
 
 (deftest protocol-test
   (let [prog "


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/sci/blob/master/doc/dev.md).
- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/sci/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
- [x] This PR contains a [test](https://github.com/babashka/sci/blob/master/doc/dev.md#tests) to prevent against future regressions

---

Fixes #785 

The crux of the issue is that the way that `satisfies?` currently turns a type into a symbol,
https://github.com/babashka/sci/blob/3e068bbd9cfdf8e39107721658a3717db092c2e0/src/sci/impl/protocols.cljc#L245-L251

does not match the way that `extend-type` and `extend-protocol` do when adding the metadata to the protocol https://github.com/babashka/sci/blob/3e068bbd9cfdf8e39107721658a3717db092c2e0/src/sci/impl/protocols.cljc#L232-L235

This PR attempts to unify the way we coerce the type to a symbol between `extend-type`, `extend-protocol` and `satisfies?`.

In addition, it also exposes a new var `clojure.core/type->str`. The rationale for it is we need to use the same machinery in two different contexts: a macro context in `extend-type` and `extend-protocol`, and at runtime in `satisfies?`. I could emit the code directly in the macro context instead, but I thought it would be better for maintenance purposes to have everything refer to a single function.

There also already exists a [type->str](https://cljs.github.io/api/cljs.core/type-GTstr) function in CLJS, so the only maybe-surprising thing for consumers is that there now exists a `clojure.core/type->symbol` function in SCI that doesn't exist in JVM Clojure.