### PR TITLE
Fix arity exception msgs for Clojure 1.10, 1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 For a list of breaking changes, check [here](#breaking-changes)
 
+## Unreleased
+
+- [#791](https://github.com/babashka/sci/issues/791): Fix friendly arity exception messages for Clojure 1.10, 1.11 ([@lread](https://github.com/lread)) 
+
 ## v0.3.32
 
 - [#767](https://github.com/babashka/sci/issues/767): Reduce advanced compiled JS output with about 20% (~900kb -> ~740kb)

--- a/project.clj
+++ b/project.clj
@@ -15,6 +15,8 @@
                  [org.babashka/sci.impl.types "0.0.2"]]
   :plugins [[lein-codox "0.10.7"]]
   :profiles {:clojure-1.9.0 {:dependencies [[org.clojure/clojure "1.9.0"]]}
+             :clojure-1.10.3 {:depdencies [[org.clojure/clojure "1.10.3"]]}
+             :clojure-1.11.1 {:dependencies [[org.clojure/clojure "1.11.1"]]}
              :native-image {:dependencies [[org.clojure/clojure "1.10.3"]]}
              :dev {:dependencies [[thheller/shadow-cljs "2.8.64"]]}
              :test {:resource-paths ["test-resources"]

--- a/script/test/jvm
+++ b/script/test/jvm
@@ -5,5 +5,8 @@ set -eo pipefail
 echo "Testing with Clojure 1.9.0"
 lein with-profiles +clojure-1.9.0 test "$@"
 
-echo "Testing with Clojure 1.10.2-alpha1"
-lein with-profiles +clojure-1.10.2-alpha1 test "$@"
+echo "Testing with Clojure 1.10.3"
+lein with-profiles +clojure-1.10.3 test "$@"
+
+echo "Testing with Clojure 1.11.1"
+lein with-profiles +clojure-1.11.1 test "$@"

--- a/src/sci/impl/utils.cljc
+++ b/src/sci/impl/utils.cljc
@@ -58,35 +58,35 @@
 
 #?(:clj
    (defn rewrite-ex-msg [ex-msg env fm]
-     (if ex-msg
-       (let [[_ printed-fn] (re-matches #"Wrong number of args \(\d+\) passed to: (.*)" ex-msg)
-             fn-pat #"(sci\.impl\.)?fns/fun/arity-([0-9])+--\d+"
-             [match _prefix arity] (re-find fn-pat ex-msg)
-             prefix "sci.impl."
-             friendly-name (when arity (str "function of arity " arity))
-             ex-msg (if (:name fm)
-                      (let [ns (symbol (str (:ns fm)))
-                            var-name (:name fm)
-                            var (get-in @env [:namespaces ns var-name])
-                            fstr (when var (let [varf (if (instance? clojure.lang.IDeref var)
-                                                        (deref var)
-                                                        var)
-                                                 varf (or
-                                                       ;; resolve macro inner fn for comparison
-                                                       (some-> varf meta :sci.impl/inner-fn)
-                                                       varf)
-                                                 fstr (clojure.lang.Compiler/demunge (str varf))
-                                                 fstr (first (str/split fstr #"@"))
-                                                 fstr (str/replace fstr (re-pattern (str "^" prefix)) "")]
-                                             fstr))]
-                        (cond (and fstr printed-fn (= fstr printed-fn))
-                              (str/replace ex-msg printed-fn
-                                           (str (:ns fm) "/" (:name fm)))
-                              friendly-name (str/replace ex-msg match friendly-name)
-                              :else ex-msg))
-                      ex-msg)]
-         ex-msg)
-       ex-msg)))
+     (when ex-msg
+       (if-let [[_ printed-fn] (re-matches #"Wrong number of args \(\d+\) passed to: (.*)" ex-msg)]
+         (let [fn-pat #"(sci\.impl\.)?fns/fun/arity-([0-9])+--\d+"
+               [fn-match prefix arity] (re-find fn-pat ex-msg)
+               friendly-name (when arity (str "function of arity " arity))]
+           (if (:name fm)
+             (let [ns (symbol (str (:ns fm)))
+                   var-name (:name fm)
+                   var (get-in @env [:namespaces ns var-name])
+                   fstr (when var (let [varf (if (instance? clojure.lang.IDeref var)
+                                               (deref var)
+                                               var)
+                                        varf (or
+                                              ;; resolve macro inner fn for comparison
+                                              (some-> varf meta :sci.impl/inner-fn)
+                                              varf)
+                                        fstr (clojure.lang.Compiler/demunge (str varf))
+                                        fstr (first (str/split fstr #"@"))
+                                        fstr (if prefix
+                                               fstr
+                                               (str/replace fstr #"^sci\.impl\." ""))]
+                                    fstr))]
+               (cond (and fstr printed-fn (= fstr printed-fn))
+                     (str/replace ex-msg printed-fn
+                                  (str (:ns fm) "/" (:name fm)))
+                     friendly-name (str/replace ex-msg fn-match friendly-name)
+                     :else ex-msg))
+             ex-msg))
+         ex-msg))))
 
 (defn rethrow-with-location-of-node
   ([ctx ^Throwable e raw-node] (rethrow-with-location-of-node ctx (:bindings ctx) e raw-node))


### PR DESCRIPTION
We were almost taking into account the `sci.impl.` fn name prefix that
shows up in Clojure 1.10+, but not quite.
Now also only applying arity conversion code to arity exception messages.

We were previously accidentally only testing against Clojure 1.9.0, so
these test failures went unnoticed.

Fixes #791

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/sci/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/sci/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/sci/blob/master/doc/dev.md#tests) to prevent against future regressions
