### PR TITLE
Protocol fun documentation parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 For a list of breaking changes, check [here](#breaking-changes)
 
+## Unreleased
+
+- [babashka/babashka#1340](https://github.com/babashka/babashka/issues/1340): Add arglists/docstring to protocol methods
+
 ## v0.4.33
 
 - [#791](https://github.com/babashka/sci/issues/791): Fix friendly arity exception messages for Clojure 1.10, 1.11

--- a/src/sci/impl/protocols.cljc
+++ b/src/sci/impl/protocols.cljc
@@ -56,9 +56,8 @@
            ~@(map (fn [[method-name & _]]
                     (let [fq-name (symbol (str current-ns) (str method-name))
                           method-meta (select-keys (get sigs-map (keyword method-name)) [:doc :arglists])
-                          method-meta (if (contains? method-meta :arglists)
-                                        (update method-meta :arglists (fn [a] (list 'quote a)))
-                                        method-meta)
+                          ; re-quote arglists
+                          method-meta (update method-meta :arglists (fn [a] (list 'quote a)))
                           impls [`(defmulti ~method-name ~method-meta clojure.core/protocol-type-impl)
                                  `(defmethod ~method-name :sci.impl.protocols/reified [x# & args#]
                                     (let [methods# (clojure.core/-reified-methods x#)]

--- a/src/sci/impl/protocols.cljc
+++ b/src/sci/impl/protocols.cljc
@@ -55,7 +55,11 @@
                                         ~extend-meta (assoc :extend-via-metadata true)))
            ~@(map (fn [[method-name & _]]
                     (let [fq-name (symbol (str current-ns) (str method-name))
-                          impls [`(defmulti ~method-name clojure.core/protocol-type-impl)
+                          method-meta (select-keys (get sigs-map (keyword method-name)) [:doc :arglists])
+                          method-meta (if (contains? method-meta :arglists)
+                                        (update method-meta :arglists (fn [a] (list 'quote a)))
+                                        method-meta)
+                          impls [`(defmulti ~method-name ~method-meta clojure.core/protocol-type-impl)
                                  `(defmethod ~method-name :sci.impl.protocols/reified [x# & args#]
                                     (let [methods# (clojure.core/-reified-methods x#)]
                                       (if-let [m# (get methods# '~method-name)]

--- a/test/sci/protocols_test.cljc
+++ b/test/sci/protocols_test.cljc
@@ -114,8 +114,7 @@
                            "([this n] [_ o p])"
                              ; not technically valid in Clojure, but won't break anything in sci
                            "-------------------------"
-                           "user/just-name"
-                           ]
+                           "user/just-name"]
           prog            '(do
                              (defprotocol Foo
                                (doced [this] "awesome docs")

--- a/test/sci/protocols_test.cljc
+++ b/test/sci/protocols_test.cljc
@@ -98,6 +98,36 @@
 (foo 1)
 "))))
 
+(deftest fn-docstring-test
+  (testing "protocol functions get docstrings and arglists"
+                            ; based on running defprotocol and doc on fns in clojure
+    (let [expected-output ["-------------------------" 
+                           "user/doced" 
+                           "([this])" 
+                           "  awesome docs" 
+                           "-------------------------" 
+                           "user/arities" 
+                           "([this a] [this a b])" 
+                           "  arity docs" 
+                           "-------------------------" 
+                           "user/nodocs" 
+                           "([this n] [_ o p])"
+                             ; not technically valid in Clojure, but won't break anything in sci
+                           "-------------------------"
+                           "user/just-name"
+                           ]
+          prog            '(do
+                             (defprotocol Foo
+                               (doced [this] "awesome docs")
+                               (arities [this a] [this a b] "arity docs")
+                               (nodocs [this n] [_ o p])
+                               (just-name))
+                             (with-out-str (clojure.repl/doc doced)
+                                           (clojure.repl/doc arities)
+                                           (clojure.repl/doc nodocs)
+                                           (clojure.repl/doc just-name)))]
+      (is (= expected-output (str/split-lines (tu/eval* (pr-str prog) {})))))))
+
 (deftest reify-test
   (let [prog "
 (defprotocol Fruit (subtotal [item]))


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/sci/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/sci/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

Aimed at directly addressing https://github.com/babashka/babashka/issues/1340

- [x] This PR contains a [test](https://github.com/babashka/sci/blob/master/doc/dev.md#tests) to prevent against future regressions

**Summary**
Add an attribute map to the multimethods created for protocol functions. The attribute map is based directly on the signature map currently parsed by `defprotocol`. Also, add a test for `doc` output based on running the same protocol definition in clojure/jvm.

**likely(?) discussion points**
- arglists aren't enforced (as in arity checks) - this is also true for 'hand-crafted' arglists, but is a variance from protocols on cl/jvm, so I wanted to call that out in case these should be captured/rendered differently
- the "no arglist" test - I wanted to capture a variety of arglist/docstring combos for this test, and it occurred to me that it's technically possible (with SCI) to specify a protocol method with no arglists; the test is primarily there to ensure that these changes don't cause any undesired behavior around the metadata, but it might not be desirable to have a test scenario that's undesirable
- cross-linking issues in changelog - I only saw one other example of referring to an issue from the bb issue list, but it wasn't a link; not sure if there's a more preferred style for linking over (or maybe just eschew the linking altogether)
