### PR TITLE
feat: Expose *print-namespace-maps* from `sci.core`

### DIFF
--- a/src/sci/core.cljc
+++ b/src/sci/core.cljc
@@ -127,6 +127,7 @@
 (def print-meta "SCI var that represents SCI's `clojure.core/*print-meta*`" sio/print-meta)
 (def print-readably "SCI var that represents SCI's `clojure.core/*print-readably*`" sio/print-readably)
 (def print-dup "SCI var that represents SCI's `clojure.core/*print-dup*`" sio/print-dup-var)
+(def print-namespace-maps "SCI var that represents SCI's `clojure.core/*print-namespace-maps*`" sio/print-namespace-maps)
 #?(:cljs (def print-fn "SCI var that represents SCI's `cljs.core/*print-fn*`" sio/print-fn))
 #?(:cljs (def print-err-fn "SCI var that represents SCI's `cljs.core/*print-err-fn*`" sio/print-err-fn))
 #?(:cljs (def print-newline "SCI var that represents SCI's `cljs.core/*print-newline*`" sio/print-newline))

--- a/test/sci/pprint_test.clj
+++ b/test/sci/pprint_test.clj
@@ -7,7 +7,8 @@
    [sci.pprint]))
 
 (defn pprint [o]
-  (binding [*out* @sci/out]
+  (binding [*out* @sci/out
+            *print-namespace-maps* @sci/print-namespace-maps]
     (pp/pprint o)))
 
 (def conf {:namespaces
@@ -42,3 +43,16 @@
 (pprint/pprint (->Foo 6))
 "
                              conf))))))
+
+
+(deftest print-namespace-maps-test
+  (is (= "{:x/a 1, :x/b 2}"
+        (str/trim
+          (sci/with-out-str
+            (sci/eval-string "
+(require '[clojure.pprint :as pprint])
+
+(binding [*print-namespace-maps* false]
+  (pprint/pprint {:x/a 1 :x/b 2}))
+"
+              conf))))))


### PR DESCRIPTION
This change exposes a new var `sci.core/print-namespace-maps` that represents the same var from SCI's `clojure.core/*print-namespace-maps*`.

This var is useful for controlling how maps w/ namespaced keys are pretty-printed.

Fixes: #809

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/sci/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/sci/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/sci/blob/master/doc/dev.md#tests) to prevent against future regressions
