### PR TITLE
Error metadata missing on some interop call exceptions (#842)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ SCI is used in [babashka](https://github.com/babashka/babashka),
 ## Unreleased
 
 - Fix for `SCI_ELIDE_VARS`
+- [#842](https://github.com/babashka/sci/issues/842) Error metadata missing on some interop calls ([@bobisageek](https://github.com/bobisageek))
 
 ## 0.5.36 (2022-11-14)
 

--- a/src/sci/impl/analyzer.cljc
+++ b/src/sci/impl/analyzer.cljc
@@ -1082,7 +1082,7 @@
   (when (< (count expr) 2)
     (throw (new #?(:clj IllegalArgumentException :cljs js/Error)
                 "Malformed member expression, expecting (.member target ...)")))
-  (analyze-dot ctx (list '. obj (cons (symbol (subs (name method-name) 1)) args))))
+  (analyze-dot ctx (with-meta (list '. obj (cons (symbol (subs (name method-name) 1)) args)) (meta expr))))
 
 (defn analyze-new [ctx [_new class-sym & args :as expr]]
   (let [ctx (without-recur-target ctx)]

--- a/test/sci/interop_test.cljc
+++ b/test/sci/interop_test.cljc
@@ -129,8 +129,6 @@
         (testing "instance members"
           (are [form]
             (let [actual (form-ex-data form)]
-              (println (str form))
-              (println actual)
               (and (tu/submap? {:type   :sci/error
                            :line   1
                            :column 1}

--- a/test/sci/interop_test.cljc
+++ b/test/sci/interop_test.cljc
@@ -1,10 +1,10 @@
 (ns sci.interop-test
   (:require
-    [clojure.string :as str]
-    [clojure.test :as test :refer [are deftest is testing #?(:cljs async)]]
-    [sci.core :as sci]
-    [sci.test-utils :as tu]
-    #?(:cljs [goog.object :as gobj]))
+   [clojure.string :as str]
+   [clojure.test :as test :refer [are deftest is testing #?(:cljs async)]]
+   [sci.core :as sci]
+   [sci.test-utils :as tu]
+   #?(:cljs [goog.object :as gobj]))
   #?(:clj (:import PublicFields)))
 
 (defn eval* [expr]


### PR DESCRIPTION
Closes #842 

Change details:
- analyzer.cljc:
  - `analyze-dot`: the "big volume" change is `let`ting `stack` once, since the proposal is to always include stack on the `Node`s. The primary behavioral change is including `stack` on the Nodes that use get-static-field (not 100% sure if this is desired or not)
  - `expand-dot*`: include `expr`'s meta on the expanded form
- interop_test.cljc:
  - require `clojure.string` for clj as well as cljs (for checking exception message contents on both platforms)
  - add a test for various instance/member access notations and asserting that exception data is always present


Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/sci/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/sci/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/sci/blob/master/doc/dev.md#tests) to prevent against future regressions
