### PR TITLE
Updated libsci docs to use existing bb script to generate .h header files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ sci.build_artifacts.txt
 .cpcache
 public
 reports
+.DS_Store
 
 # Emacs
 *~

--- a/build-libsci-headers.clj
+++ b/build-libsci-headers.clj
@@ -1,0 +1,89 @@
+(ns libsci-tasks
+  (:require [babashka.deps :as deps]
+            [babashka.fs :as fs]
+            [babashka.process :as p]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is run-all-tests testing]]))
+
+(defn- setup-clojure-lein-ps1-cmd
+  "Return PowerShell command to invoke `lein.ps1` script installed as part
+  of DeLaGuardo's setup-clojure GitHub action on MS-Windows."
+  []
+  (when-let [lein-home (System/getenv "LEIN_HOME")]
+    (let [lein-ps1 (fs/path lein-home "bin" "lein.ps1")]
+      (when (fs/exists? lein-ps1)
+        (str "powershell -File " lein-ps1)))))
+
+(defn compile-native
+  "Compile libsci as native library in `libsci/target/`.
+  It requires both leiningen and graalvm being installed.
+
+  It expects to find the graalvm home path in the GRAALVM_HOME env
+  var and lein in PATH."
+  []
+  (let [_   (println :lein (fs/which "lein"))
+        graalvm-home (or (System/getenv "GRAALVM_HOME")
+                         (throw (Exception. "Please set GRAALVM_HOME.")))
+        java-home (str (fs/path graalvm-home "bin"))
+
+        lein  (str (or (fs/which "lein")
+                       ;; temporary workaround for
+                       ;; https://github.com/DeLaGuardo/setup-clojure/issues/78
+                       (setup-clojure-lein-ps1-cmd)
+                       (throw (Exception. "Cannot find lein in PATH."))))
+        sci-version (str/trim (slurp "resources/SCI_VERSION"))
+        sci-jar (str "target/sci-" sci-version "-standalone.jar")
+        svm-jar (str (or (first (fs/glob graalvm-home "**/svm.jar"))
+                         (do (p/shell (str (fs/file graalvm-home "bin" "gu")) "install" "native-image")
+                             (first (fs/glob graalvm-home "**/svm.jar")))
+                         (throw (Exception. "Cannot find `svm.jar` in GRAALVM_HOME."))))]
+    (prn :graalvm-home graalvm-home :java-home java-home :svm-jar svm-jar :lein lein)
+    (p/shell lein "with-profiles" "+libsci,+native-image" "do" "clean," "uberjar")
+
+    (let [javac (str (fs/file graalvm-home "bin" "javac"))]
+      (p/shell javac
+               "-cp" (str/join fs/path-separator [sci-jar svm-jar])
+               "libsci/src/sci/impl/LibSci.java"))
+
+    (let [native-image (str (fs/path graalvm-home "bin"
+                                     (if (fs/windows?) "native-image.cmd" "native-image")))]
+      (p/shell native-image
+               "-jar" sci-jar
+               "-cp" "libsci/src"
+               "-H:Name=libsci"
+               "--shared"   "-H:+ReportExceptionStackTraces"
+               "-J-Dclojure.spec.skip-macros=true"
+               "-J-Dclojure.compiler.direct-linking=true"
+               "-H:IncludeResources=SCI_VERSION"
+               "-H:ReflectionConfigurationFiles=reflection.json"
+               "--initialize-at-build-time"
+               "-H:Log=registerResource:"
+               "--verbose"
+               "--no-fallback"
+               "--no-server"
+               "--enable-preview"
+               "-J-Xmx3g"))
+
+    (p/shell lein "clean")
+    (deps/clojure ["-Spath" "-Sdeps" "{:deps {borkdude/deps.clj {:mvn/version \"0.0.1\"}}}"])
+
+    (fs/delete-tree "libsci/target")
+    (fs/create-dirs "libsci/target")
+
+    (let [lib (cond->> (System/mapLibraryName "sci")
+                (fs/windows?)
+                (str "lib"))]
+      (doseq [path ["graal_isolate_dynamic.h" "libsci.h" "graal_isolate.h" lib "libsci_dynamic.h"]]
+        (fs/move path "libsci/target"))
+      (when (fs/windows?) (fs/move "libsci.lib" "libsci/target/sci.lib")))))
+
+(comment
+  run 'bb build-libsci-headers.clj' to generate the following files
+
+  graal_isolate_dynamic.h 
+  graal_isolate.h 
+  libsci_dynamic.h
+  libsci.dylib
+  libsci.h)
+  
+(compile-native)

--- a/doc/libsci.md
+++ b/doc/libsci.md
@@ -89,18 +89,15 @@ and C types.
 The Clojure and Java code is compiled into .class files. Next, we compile those
 .class files into a shared library using `native-image`:
 
+Run this babashka script to create header files
 ``` shell
-$ $GRAALVM_HOME/bin/native-image \
-  -jar $SCI_JAR \
-  -cp libsci/src \
-  -H:Name=libsci \
-  --shared \
-  ...
+bb build-libsci-headers.clj
+
 ```
 
 This begets the files `graal_isolate_dynamic.h`, `graal_isolate.h`, `libsci.h`,
 `libsci.dylib` (on linux `libsci.so`, on MS-Windows `libsci.dll`) and `libsci_dynamic.h`.
-We move all these files to `libsci/target`.
+The script moves all these files to `libsci/target`.
 
 In addtion, on MS-Windows, there is one more library file,
 `libsci.lib`, which should be copied over as `sci.lib`.


### PR DESCRIPTION
Hi,

Following up on our Slack discussion yesterday.
https://app.slack.com/client/T03RZGPFR/CAJN79WNT/thread/CAJN79WNT-1696657493.369429

When following the instructions in the libsci.md documentation I couldn't understand what to do next as the parameters for calling GRAALVM_HOME/bin/native-image were unclear to me.

An existing bb script libsci_tasks.clj in libsci/bb contains a function that ran the GRAALVM_HOME/bin/native-image step of the instructions passing the correct parameters and moved the files generated to the correct folder.

I used that function in a bb script by itself and ran the script to move onto the next steps in the instructions.
This PR contains the new bb script containing only that one function (compile-native) and the changes to the libsci.md instructions that explain how to use the script.

