### PR TITLE
Fix docstring of copy-var

### DIFF
--- a/API.md
+++ b/API.md
@@ -104,7 +104,7 @@ needing something from the dark `impl` side!
 Function.
 
 Establish thread local binding of dynamic var
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L48-L51">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L47-L50">Source</a></sub></p>
 
 -----
 # <a name="sci.async">sci.async</a>
@@ -122,7 +122,7 @@ Establish thread local binding of dynamic var
 
 Mark promise to be flatteded into top level async evaluation, similar
   to top level await.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/async.cljs#L185-L190">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/async.cljs#L192-L197">Source</a></sub></p>
 
 ## <a name="sci.async/await?">`await?`</a><a name="sci.async/await?"></a>
 ``` clojure
@@ -131,7 +131,7 @@ Mark promise to be flatteded into top level async evaluation, similar
 ```
 
 Check if promise was marked with [`await`](#sci.async/await).
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/async.cljs#L192-L195">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/async.cljs#L199-L202">Source</a></sub></p>
 
 ## <a name="sci.async/eval-form">`eval-form`</a><a name="sci.async/eval-form"></a>
 ``` clojure
@@ -140,23 +140,24 @@ Check if promise was marked with [`await`](#sci.async/await).
 ```
 
 Eval single form in ctx.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/async.cljs#L135-L138">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/async.cljs#L138-L141">Source</a></sub></p>
 
 ## <a name="sci.async/eval-form+">`eval-form+`</a><a name="sci.async/eval-form+"></a>
 ``` clojure
 
-(eval-form+ ctx form)
+(eval-form+ ctx s)
+(eval-form+ ctx form opts)
 ```
 
 Eval single form in ctx, return map of `:val` and `:ns`.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/async.cljs#L140-L143">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/async.cljs#L143-L150">Source</a></sub></p>
 
 ## <a name="sci.async/eval-string*">`eval-string*`</a><a name="sci.async/eval-string*"></a>
 ``` clojure
 
 (eval-string* ctx s)
 ```
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/async.cljs#L170-L172">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/async.cljs#L177-L179">Source</a></sub></p>
 
 ## <a name="sci.async/eval-string+">`eval-string+`</a><a name="sci.async/eval-string+"></a>
 ``` clojure
@@ -168,7 +169,7 @@ Eval single form in ctx, return map of `:val` and `:ns`.
 Same as eval-string* but returns map with `:val`, the evaluation
   result, and `:ns`, the last active namespace. The return value can
   be passed back into `opts` to preserve the namespace state.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/async.cljs#L174-L183">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/async.cljs#L181-L190">Source</a></sub></p>
 
 ## <a name="sci.async/require">`require`</a><a name="sci.async/require"></a>
 
@@ -177,7 +178,7 @@ Same as eval-string* but returns map with `:val`, the evaluation
 
 Async require that can be substituted for sync require by
   `{:namespaces {'clojure.core {'require scia/require}}}`
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/async.cljs#L203-L206">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/async.cljs#L210-L213">Source</a></sub></p>
 
 -----
 # <a name="sci.core">sci.core</a>
@@ -192,25 +193,25 @@ The main SCI API namespace.
 
 
 
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L141-L141">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L143-L143">Source</a></sub></p>
 
 ## <a name="sci.core/*2">`*2`</a><a name="sci.core/*2"></a>
 
 
 
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L142-L142">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L144-L144">Source</a></sub></p>
 
 ## <a name="sci.core/*3">`*3`</a><a name="sci.core/*3"></a>
 
 
 
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L143-L143">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L145-L145">Source</a></sub></p>
 
 ## <a name="sci.core/*e">`*e`</a><a name="sci.core/*e"></a>
 
 
 
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L144-L144">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L146-L146">Source</a></sub></p>
 
 ## <a name="sci.core/add-class!">`add-class!`</a><a name="sci.core/add-class!"></a>
 ``` clojure
@@ -220,7 +221,7 @@ The main SCI API namespace.
 
 Adds class (JVM class or JS object) to `ctx` as `class-name` (a
   symbol). Returns mutated context.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L502-L512">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L508-L518">Source</a></sub></p>
 
 ## <a name="sci.core/add-import!">`add-import!`</a><a name="sci.core/add-import!"></a>
 ``` clojure
@@ -229,7 +230,7 @@ Adds class (JVM class or JS object) to `ctx` as `class-name` (a
 ```
 
 Adds import of class named by `class-name` (a symbol) to namespace named by [`ns-name`](#sci.core/ns-name) (a symbol) under alias `alias` (a symbol). Returns mutated context.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L495-L500">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L497-L506">Source</a></sub></p>
 
 ## <a name="sci.core/add-js-lib!">`add-js-lib!`</a><a name="sci.core/add-js-lib!"></a>
 ``` clojure
@@ -238,7 +239,7 @@ Adds import of class named by `class-name` (a symbol) to namespace named by [`ns
 ```
 
 Add js library to context, so it can be used with `require`.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L554-L558">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L560-L564">Source</a></sub></p>
 
 ## <a name="sci.core/add-namespace!">`add-namespace!`</a><a name="sci.core/add-namespace!"></a>
 ``` clojure
@@ -248,7 +249,7 @@ Add js library to context, so it can be used with `require`.
 
 Adds namespace map `ns-map` named by the symbol [`ns-name`](#sci.core/ns-name) to
   `ctx`. Returns mutated context.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L514-L519">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L520-L525">Source</a></sub></p>
 
 ## <a name="sci.core/all-ns">`all-ns`</a><a name="sci.core/all-ns"></a>
 ``` clojure
@@ -257,7 +258,7 @@ Adds namespace map `ns-map` named by the symbol [`ns-name`](#sci.core/ns-name) t
 ```
 
 Returns all SCI ns objects in the `ctx`
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L526-L529">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L532-L535">Source</a></sub></p>
 
 ## <a name="sci.core/alter-var-root">`alter-var-root`</a><a name="sci.core/alter-var-root"></a>
 ``` clojure
@@ -268,7 +269,7 @@ Returns all SCI ns objects in the `ctx`
 
 Atomically alters the root binding of sci var v by applying f to its
   current value plus any args.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L204-L212">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L206-L214">Source</a></sub></p>
 
 ## <a name="sci.core/assert">`assert`</a><a name="sci.core/assert"></a>
 
@@ -276,7 +277,7 @@ Atomically alters the root binding of sci var v by applying f to its
 
 
 SCI var that represents SCI's clojure.core/*assert*
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L139-L139">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L141-L141">Source</a></sub></p>
 
 ## <a name="sci.core/binding">`binding`</a><a name="sci.core/binding"></a>
 ``` clojure
@@ -287,7 +288,7 @@ Function.
 
 Macro for binding sci vars. Must be called with a vector of sci
   dynamic vars to values.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L114-L121">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L116-L123">Source</a></sub></p>
 
 ## <a name="sci.core/copy-ns">`copy-ns`</a><a name="sci.core/copy-ns"></a>
 ``` clojure
@@ -318,7 +319,7 @@ Returns map of names to SCI vars as a result of copying public
   important for ClojureScript to not pull in vars into the compiled
   JS. Any additional vars can be added after the fact with sci/copy-var
   manually.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L406-L493">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L408-L495">Source</a></sub></p>
 
 ## <a name="sci.core/copy-var">`copy-var`</a><a name="sci.core/copy-var"></a>
 ``` clojure
@@ -329,9 +330,12 @@ Returns map of names to SCI vars as a result of copying public
 Function.
 
 Copies contents from var `sym` to a new sci var. The value [`ns`](#sci.core/ns) is an
-  object created with [`sci.core/create-ns`](#sci.core/create-ns). If new-name is supplied, the
-  copied var will be named new-name.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L62-L83">Source</a></sub></p>
+  object created with [`sci.core/create-ns`](#sci.core/create-ns).
+
+  Options:
+
+  - :name: The name of the copied var. Defaults to the original var name.
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L61-L85">Source</a></sub></p>
 
 ## <a name="sci.core/copy-var*">`copy-var*`</a><a name="sci.core/copy-var*"></a>
 ``` clojure
@@ -340,7 +344,7 @@ Copies contents from var `sym` to a new sci var. The value [`ns`](#sci.core/ns) 
 ```
 
 Copies Clojure var to SCI var. Runtime analog of compile time [`copy-var`](#sci.core/copy-var).
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L85-L100">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L87-L102">Source</a></sub></p>
 
 ## <a name="sci.core/create-ns">`create-ns`</a><a name="sci.core/create-ns"></a>
 ``` clojure
@@ -350,7 +354,7 @@ Copies Clojure var to SCI var. Runtime analog of compile time [`copy-var`](#sci.
 ```
 
 Creates namespace object. Can be used in var metadata.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L291-L295">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L293-L297">Source</a></sub></p>
 
 ## <a name="sci.core/enable-unrestricted-access!">`enable-unrestricted-access!`</a><a name="sci.core/enable-unrestricted-access!"></a>
 ``` clojure
@@ -364,7 +368,7 @@ Calling this will enable
   - In CLJS: instance method calls are not restricted to only `:classes`
 
   In the future, more unrestricted access may be added, so only use this when you're not using SCI as a sandbox.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L531-L540">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L537-L546">Source</a></sub></p>
 
 ## <a name="sci.core/err">`err`</a><a name="sci.core/err"></a>
 
@@ -372,7 +376,7 @@ Calling this will enable
 
 
 SCI var that represents SCI's `clojure.core/*err*`
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L126-L126">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L128-L128">Source</a></sub></p>
 
 ## <a name="sci.core/eval-form">`eval-form`</a><a name="sci.core/eval-form"></a>
 ``` clojure
@@ -384,7 +388,7 @@ Evaluates form (as produced by [`parse-string`](#sci.core/parse-string) or [`par
   context of `ctx` (as produced with [`init`](#sci.core/init)). To allow namespace
   switches, establish root binding of `sci/ns` with `sci/binding` or
   `sci/with-bindings.`
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L338-L345">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L340-L347">Source</a></sub></p>
 
 ## <a name="sci.core/eval-string">`eval-string`</a><a name="sci.core/eval-string"></a>
 ``` clojure
@@ -413,7 +417,7 @@ Evaluates string `s` as one or multiple Clojure expressions using the Small Cloj
   - `:features`: when provided a non-empty set of keywords, sci will process reader conditionals using these features (e.g. #{:bb}).
 
   - `:ns-aliases`: a map of aliases to namespaces that are globally valid, e.g. `{'clojure.test 'cljs.test}`
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L225-L248">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L227-L250">Source</a></sub></p>
 
 ## <a name="sci.core/eval-string*">`eval-string*`</a><a name="sci.core/eval-string*"></a>
 ``` clojure
@@ -423,7 +427,7 @@ Evaluates string `s` as one or multiple Clojure expressions using the Small Cloj
 
 Evaluates string `s` in the context of `ctx` (as produced with
   [`init`](#sci.core/init)).
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L270-L274">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L272-L276">Source</a></sub></p>
 
 ## <a name="sci.core/eval-string+">`eval-string+`</a><a name="sci.core/eval-string+"></a>
 ``` clojure
@@ -441,7 +445,7 @@ Evaluates string `s` in the context of `ctx` (as produced with
   Returns map with:
   * `:val` - the evaluated value
   * `:ns` - the namespace object
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L276-L289">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L278-L291">Source</a></sub></p>
 
 ## <a name="sci.core/file">`file`</a><a name="sci.core/file"></a>
 
@@ -449,7 +453,7 @@ Evaluates string `s` in the context of `ctx` (as produced with
 
 
 SCI var that represents SCI's `clojure.core/*file*`
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L128-L128">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L130-L130">Source</a></sub></p>
 
 ## <a name="sci.core/find-ns">`find-ns`</a><a name="sci.core/find-ns"></a>
 ``` clojure
@@ -458,7 +462,7 @@ SCI var that represents SCI's `clojure.core/*file*`
 ```
 
 Returns SCI ns object as created with `sci/create-ns` from `ctx` found by `ns-sym`.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L521-L524">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L527-L530">Source</a></sub></p>
 
 ## <a name="sci.core/fork">`fork`</a><a name="sci.core/fork"></a>
 ``` clojure
@@ -469,7 +473,7 @@ Returns SCI ns object as created with `sci/create-ns` from `ctx` found by `ns-sy
 Forks a context (as produced with [`init`](#sci.core/init)) into a new context. Any new
   vars created in the new context won't be visible in the original
   context.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L263-L268">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L265-L270">Source</a></sub></p>
 
 ## <a name="sci.core/format-stacktrace">`format-stacktrace`</a><a name="sci.core/format-stacktrace"></a>
 ``` clojure
@@ -478,7 +482,7 @@ Forks a context (as produced with [`init`](#sci.core/init)) into a new context. 
 ```
 
 Returns a list of formatted stack trace elements as strings from stacktrace.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L352-L355">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L354-L357">Source</a></sub></p>
 
 ## <a name="sci.core/future">`future`</a><a name="sci.core/future"></a>
 ``` clojure
@@ -488,21 +492,21 @@ Returns a list of formatted stack trace elements as strings from stacktrace.
 Function.
 
 Like clojure.core/future but also conveys sci bindings to the thread.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L178-L183">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L180-L185">Source</a></sub></p>
 
 ## <a name="sci.core/get-column-number">`get-column-number`</a><a name="sci.core/get-column-number"></a>
 ``` clojure
 
 (get-column-number reader)
 ```
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L315-L316">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L317-L318">Source</a></sub></p>
 
 ## <a name="sci.core/get-line-number">`get-line-number`</a><a name="sci.core/get-line-number"></a>
 ``` clojure
 
 (get-line-number reader)
 ```
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L312-L313">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L314-L315">Source</a></sub></p>
 
 ## <a name="sci.core/in">`in`</a><a name="sci.core/in"></a>
 
@@ -510,7 +514,7 @@ Like clojure.core/future but also conveys sci bindings to the thread.
 
 
 SCI var that represents SCI's `clojure.core/*in*`
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L124-L124">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L126-L126">Source</a></sub></p>
 
 ## <a name="sci.core/init">`init`</a><a name="sci.core/init"></a>
 ``` clojure
@@ -522,7 +526,7 @@ Creates an initial sci context from given options `opts`. The context
   can be used with [`eval-string*`](#sci.core/eval-string*). See [`eval-string`](#sci.core/eval-string) for available
   options. The internal organization of the context is implementation
   detail and may change in the future.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L250-L256">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L252-L258">Source</a></sub></p>
 
 ## <a name="sci.core/intern">`intern`</a><a name="sci.core/intern"></a>
 ``` clojure
@@ -536,7 +540,7 @@ Finds or creates a sci var named by the symbol name in the namespace
   binding to val if supplied. The namespace must exist in the ctx. The
   sci var will adopt any metadata from the name symbol.  Returns the
   sci var.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L214-L223">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L216-L225">Source</a></sub></p>
 
 ## <a name="sci.core/merge-opts">`merge-opts`</a><a name="sci.core/merge-opts"></a>
 ``` clojure
@@ -545,7 +549,7 @@ Finds or creates a sci var named by the symbol name in the namespace
 ```
 
 Updates a context with opts merged in and returns it.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L258-L261">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L260-L263">Source</a></sub></p>
 
 ## <a name="sci.core/new-dynamic-var">`new-dynamic-var`</a><a name="sci.core/new-dynamic-var"></a>
 ``` clojure
@@ -556,7 +560,7 @@ Updates a context with opts merged in and returns it.
 ```
 
 Same as new-var but adds :dynamic true to meta.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L41-L46">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L40-L45">Source</a></sub></p>
 
 ## <a name="sci.core/new-macro-var">`new-macro-var`</a><a name="sci.core/new-macro-var"></a>
 ``` clojure
@@ -567,7 +571,7 @@ Same as new-var but adds :dynamic true to meta.
 
 Same as new-var but adds :macro true to meta as well
   as :sci/macro true to meta of the fn itself.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L53-L60">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L52-L59">Source</a></sub></p>
 
 ## <a name="sci.core/new-var">`new-var`</a><a name="sci.core/new-var"></a>
 ``` clojure
@@ -578,14 +582,14 @@ Same as new-var but adds :macro true to meta as well
 ```
 
 Returns a new sci var.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L34-L39">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L33-L38">Source</a></sub></p>
 
 ## <a name="sci.core/normalize-meta">`normalize-meta`</a><a name="sci.core/normalize-meta"></a>
 ``` clojure
 
 (normalize-meta m)
 ```
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L389-L392">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L391-L394">Source</a></sub></p>
 
 ## <a name="sci.core/ns">`ns`</a><a name="sci.core/ns"></a>
 
@@ -593,7 +597,7 @@ Returns a new sci var.
 
 
 SCI var that represents SCI's `clojure.core/*ns*`
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L127-L127">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L129-L129">Source</a></sub></p>
 
 ## <a name="sci.core/ns-name">`ns-name`</a><a name="sci.core/ns-name"></a>
 ``` clojure
@@ -602,7 +606,7 @@ SCI var that represents SCI's `clojure.core/*ns*`
 ```
 
 Returns name of SCI ns as symbol.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L357-L360">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L359-L362">Source</a></sub></p>
 
 ## <a name="sci.core/out">`out`</a><a name="sci.core/out"></a>
 
@@ -610,7 +614,7 @@ Returns name of SCI ns as symbol.
 
 
 SCI var that represents SCI's `clojure.core/*out*`
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L125-L125">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L127-L127">Source</a></sub></p>
 
 ## <a name="sci.core/parse-next">`parse-next`</a><a name="sci.core/parse-next"></a>
 ``` clojure
@@ -620,7 +624,7 @@ SCI var that represents SCI's `clojure.core/*out*`
 ```
 
 Parses next form from reader
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L318-L326">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L320-L328">Source</a></sub></p>
 
 ## <a name="sci.core/parse-next+string">`parse-next+string`</a><a name="sci.core/parse-next+string"></a>
 ``` clojure
@@ -630,7 +634,7 @@ Parses next form from reader
 ```
 
 Parses next form from reader
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L328-L336">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L330-L338">Source</a></sub></p>
 
 ## <a name="sci.core/parse-string">`parse-string`</a><a name="sci.core/parse-string"></a>
 ``` clojure
@@ -640,7 +644,7 @@ Parses next form from reader
 
 Parses string `s` in the context of `ctx` (as produced with
   [`init`](#sci.core/init)).
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L297-L301">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L299-L303">Source</a></sub></p>
 
 ## <a name="sci.core/pmap">`pmap`</a><a name="sci.core/pmap"></a>
 ``` clojure
@@ -650,7 +654,7 @@ Parses string `s` in the context of `ctx` (as produced with
 ```
 
 Like clojure.core/pmap but also conveys sci bindings to the threads.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L185-L202">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L187-L204">Source</a></sub></p>
 
 ## <a name="sci.core/print-dup">`print-dup`</a><a name="sci.core/print-dup"></a>
 
@@ -658,7 +662,7 @@ Like clojure.core/pmap but also conveys sci bindings to the threads.
 
 
 SCI var that represents SCI's `clojure.core/*print-dup*`
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L134-L134">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L136-L136">Source</a></sub></p>
 
 ## <a name="sci.core/print-err-fn">`print-err-fn`</a><a name="sci.core/print-err-fn"></a>
 
@@ -666,7 +670,7 @@ SCI var that represents SCI's `clojure.core/*print-dup*`
 
 
 SCI var that represents SCI's `cljs.core/*print-err-fn*`
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L137-L137">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L139-L139">Source</a></sub></p>
 
 ## <a name="sci.core/print-fn">`print-fn`</a><a name="sci.core/print-fn"></a>
 
@@ -674,7 +678,7 @@ SCI var that represents SCI's `cljs.core/*print-err-fn*`
 
 
 SCI var that represents SCI's `cljs.core/*print-fn*`
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L136-L136">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L138-L138">Source</a></sub></p>
 
 ## <a name="sci.core/print-length">`print-length`</a><a name="sci.core/print-length"></a>
 
@@ -682,7 +686,7 @@ SCI var that represents SCI's `cljs.core/*print-fn*`
 
 
 SCI var that represents SCI's `clojure.core/*print-length*`
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L130-L130">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L132-L132">Source</a></sub></p>
 
 ## <a name="sci.core/print-level">`print-level`</a><a name="sci.core/print-level"></a>
 
@@ -690,7 +694,7 @@ SCI var that represents SCI's `clojure.core/*print-length*`
 
 
 SCI var that represents SCI's `clojure.core/*print-level*`
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L131-L131">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L133-L133">Source</a></sub></p>
 
 ## <a name="sci.core/print-meta">`print-meta`</a><a name="sci.core/print-meta"></a>
 
@@ -698,7 +702,7 @@ SCI var that represents SCI's `clojure.core/*print-level*`
 
 
 SCI var that represents SCI's `clojure.core/*print-meta*`
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L132-L132">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L134-L134">Source</a></sub></p>
 
 ## <a name="sci.core/print-namespace-maps">`print-namespace-maps`</a><a name="sci.core/print-namespace-maps"></a>
 
@@ -706,7 +710,7 @@ SCI var that represents SCI's `clojure.core/*print-meta*`
 
 
 SCI var that represents SCI's `clojure.core/*print-namespace-maps*`
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L135-L135">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L137-L137">Source</a></sub></p>
 
 ## <a name="sci.core/print-newline">`print-newline`</a><a name="sci.core/print-newline"></a>
 
@@ -714,7 +718,7 @@ SCI var that represents SCI's `clojure.core/*print-namespace-maps*`
 
 
 SCI var that represents SCI's `cljs.core/*print-newline*`
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L138-L138">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L140-L140">Source</a></sub></p>
 
 ## <a name="sci.core/print-readably">`print-readably`</a><a name="sci.core/print-readably"></a>
 
@@ -722,7 +726,7 @@ SCI var that represents SCI's `cljs.core/*print-newline*`
 
 
 SCI var that represents SCI's `clojure.core/*print-readably*`
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L133-L133">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L135-L135">Source</a></sub></p>
 
 ## <a name="sci.core/read-eval">`read-eval`</a><a name="sci.core/read-eval"></a>
 
@@ -730,7 +734,7 @@ SCI var that represents SCI's `clojure.core/*print-readably*`
 
 
 SCI var that represents SCI's `clojure.core/*read-eval*`
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L129-L129">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L131-L131">Source</a></sub></p>
 
 ## <a name="sci.core/reader">`reader`</a><a name="sci.core/reader"></a>
 ``` clojure
@@ -740,21 +744,21 @@ SCI var that represents SCI's `clojure.core/*read-eval*`
 
 Coerces x into indexing pushback-reader to be used with
   parse-next. Accepts: string or java.io.Reader.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L303-L307">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L305-L309">Source</a></sub></p>
 
 ## <a name="sci.core/resolve">`resolve`</a><a name="sci.core/resolve"></a>
 ``` clojure
 
 (resolve ctx sym)
 ```
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L550-L551">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L556-L557">Source</a></sub></p>
 
 ## <a name="sci.core/source-reader">`source-reader`</a><a name="sci.core/source-reader"></a>
 ``` clojure
 
 (source-reader x)
 ```
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L309-L310">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L311-L312">Source</a></sub></p>
 
 ## <a name="sci.core/stacktrace">`stacktrace`</a><a name="sci.core/stacktrace"></a>
 ``` clojure
@@ -763,7 +767,7 @@ Coerces x into indexing pushback-reader to be used with
 ```
 
 Returns list of stacktrace element maps from exception, if available.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L347-L350">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L349-L352">Source</a></sub></p>
 
 ## <a name="sci.core/var->symbol">`var->symbol`</a><a name="sci.core/var->symbol"></a>
 ``` clojure
@@ -772,7 +776,7 @@ Returns list of stacktrace element maps from exception, if available.
 ```
 
 Returns a fully qualified symbol from a `sci.lang.Var`
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L542-L548">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L548-L554">Source</a></sub></p>
 
 ## <a name="sci.core/with-bindings">`with-bindings`</a><a name="sci.core/with-bindings"></a>
 ``` clojure
@@ -783,7 +787,7 @@ Function.
 
 Macro for binding sci vars. Must be called with map of sci dynamic
   vars to values. Used in babashka.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L103-L112">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L105-L114">Source</a></sub></p>
 
 ## <a name="sci.core/with-in-str">`with-in-str`</a><a name="sci.core/with-in-str"></a>
 ``` clojure
@@ -794,7 +798,7 @@ Function.
 
 Evaluates body in a context in which sci's *in* is bound to a fresh
   StringReader initialized with the string s.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L149-L156">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L151-L158">Source</a></sub></p>
 
 ## <a name="sci.core/with-out-str">`with-out-str`</a><a name="sci.core/with-out-str"></a>
 ``` clojure
@@ -806,7 +810,7 @@ Function.
 Evaluates exprs in a context in which sci's *out* is bound to a fresh
   StringWriter.  Returns the string created by any nested printing
   calls.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L159-L175">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/core.cljc#L161-L177">Source</a></sub></p>
 
 -----
 # <a name="sci.ctx-store">sci.ctx-store</a>
@@ -874,7 +878,7 @@ Bind `ctx` during execution of body.
 Representation of a SCI namespace, created e.g. with `(create-ns 'foo)`.
       The fields of this type are implementation detail and should not be accessed
       directly.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/lang.cljc#L254-L274">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/lang.cljc#L263-L283">Source</a></sub></p>
 
 ## <a name="sci.lang/Type">`Type`</a><a name="sci.lang/Type"></a>
 
@@ -892,7 +896,7 @@ Representation of a SCI custom type, created e.g. with `(defrecord Foo [])`. The
 Representation of a SCI var, created e.g. with `(defn foo [])`
     The fields of this type are implementation detail and should not be accessed
     directly.
-<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/lang.cljc#L89-L246">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/sci/blob/master/src/sci/lang.cljc#L89-L255">Source</a></sub></p>
 
 ## <a name="sci.lang/notify-watches">`notify-watches`</a><a name="sci.lang/notify-watches"></a>
 ``` clojure

--- a/src/sci/core.cljc
+++ b/src/sci/core.cljc
@@ -60,8 +60,11 @@
 
 (defmacro copy-var
   "Copies contents from var `sym` to a new sci var. The value `ns` is an
-  object created with `sci.core/create-ns`. If new-name is supplied, the
-  copied var will be named new-name."
+  object created with `sci.core/create-ns`.
+
+  Options:
+
+  - :name: The name of the copied var. Defaults to the original var name."
   ([sym ns]
    `(copy-var ~sym ~ns nil))
   ([sym ns opts]


### PR DESCRIPTION
Just a tiny docstring fix, I also ran `bb quickdoc` which it turns out fixed a couple of outdated links in unrelated files. (might be a good idea to automate in Github Actions?)

- [x] I have read the [developer documentation](https://github.com/babashka/sci/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/sci/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/sci/blob/master/doc/dev.md#tests) to prevent against future regressions
