### PR TITLE
Fix overload selection for a false argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ SCI is used in [babashka](https://github.com/babashka/babashka),
 
 ## Unreleased
 
+- Fix interop with a `false` argument: `(Boolean. false)` picked the `String` overload
 - Caches resolved JVM instance methods per call site for performance
 - Fix [babashka#2030](https://github.com/babashka/babashka/issues/2030): `aset` on a primitive array was reflective and 170x slower than `aset-double`
 - Bump edamame to `1.6.43`

--- a/src/sci/impl/reflector.cljc
+++ b/src/sci/impl/reflector.cljc
@@ -219,7 +219,7 @@
                                    (if (and (nil? t) (some? arg))
                                      (.getClass ^Object arg)
                                      t))
-                                 (when arg (.getClass ^Object arg)))
+                                 (when-some [a arg] (.getClass ^Object a)))
                       param-type (aget params i)]
                   (if (param-arg-type-match? param-type arg-type)
                     (recur (inc i))

--- a/test/sci/interop_test.cljc
+++ b/test/sci/interop_test.cljc
@@ -155,6 +155,13 @@
      (is (= "dude" (eval* "(new String (str \"dude\"))")))))
 
 #?(:clj
+   (deftest false-arg-overload-test
+     (testing "false picks the boolean overload, not the String one"
+       (is (= [false false false]
+              (tu/eval* "[(Boolean. false) (Boolean/valueOf false) (Boolean/logicalAnd true false)]"
+                        {:classes {'Boolean Boolean}}))))))
+
+#?(:clj
    (deftest import-test
      (is (true? (eval* "(class? (import clojure.lang.ExceptionInfo))")))
      (is (some? (eval* "(import clojure.lang.ExceptionInfo) ExceptionInfo")))

--- a/test/sci/interop_test.cljc
+++ b/test/sci/interop_test.cljc
@@ -156,10 +156,12 @@
 
 #?(:clj
    (deftest false-arg-overload-test
-     (testing "false picks the boolean overload, not the String one"
-       (is (= [false false false]
-              (tu/eval* "[(Boolean. false) (Boolean/valueOf false) (Boolean/logicalAnd true false)]"
-                        {:classes {'Boolean Boolean}}))))))
+     (testing "false picks the boolean overload, not a reference one"
+       (is (= ["false" "true"] (eval* "[(String/valueOf false) (String/valueOf true)]")))
+       (when-not tu/native?
+         (is (= [false false false]
+                (tu/eval* "[(Boolean. false) (Boolean/valueOf false) (Boolean/logicalAnd true false)]"
+                          {:classes {'Boolean Boolean}})))))))
 
 #?(:clj
    (deftest import-test


### PR DESCRIPTION
is-congruent? derived the argument class with (when arg ...), so false read as nil and only the non-primitive overload matched. (Boolean. false) and (Boolean/valueOf false) then picked the String overload and threw ClassCastException. Use when-some, like the Java Reflector's null check.
